### PR TITLE
Fix the handling of `DEFAULT` values for the postgresql_database resource.

### DIFF
--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -148,34 +148,45 @@ func resourcePostgreSQLDatabaseCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	switch v, ok := d.GetOk(dbTemplateAttr); {
+	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
+		fmt.Fprint(b, " TEMPLATE DEFAULT")
 	case ok:
 		fmt.Fprint(b, " TEMPLATE ", pq.QuoteIdentifier(v.(string)))
-	case v.(string) == "", strings.ToUpper(v.(string)) != "DEFAULT":
+	case v.(string) == "":
 		fmt.Fprint(b, " TEMPLATE template0")
 	}
 
 	switch v, ok := d.GetOk(dbEncodingAttr); {
+	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
+		fmt.Fprintf(b, " ENCODING DEFAULT")
 	case ok:
 		fmt.Fprint(b, " ENCODING ", pq.QuoteIdentifier(v.(string)))
-	case v.(string) == "", strings.ToUpper(v.(string)) != "DEFAULT":
+	case v.(string) == "":
 		fmt.Fprint(b, ` ENCODING "UTF8"`)
 	}
 
 	switch v, ok := d.GetOk(dbCollationAttr); {
+	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
+		fmt.Fprintf(b, " LC_COLLATE DEFAULT")
 	case ok:
 		fmt.Fprint(b, " LC_COLLATE ", pq.QuoteIdentifier(v.(string)))
-	case v.(string) == "", strings.ToUpper(v.(string)) != "DEFAULT":
+	case v.(string) == "":
 		fmt.Fprint(b, ` LC_COLLATE "C"`)
 	}
 
 	switch v, ok := d.GetOk(dbCTypeAttr); {
+	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
+		fmt.Fprintf(b, " LC_CTYPE DEFAULT")
 	case ok:
 		fmt.Fprint(b, " LC_CTYPE ", pq.QuoteIdentifier(v.(string)))
 	case v.(string) == "", strings.ToUpper(v.(string)) != "DEFAULT":
 		fmt.Fprint(b, ` LC_CTYPE "C"`)
 	}
 
-	if v, ok := d.GetOk(dbTablespaceAttr); ok {
+	switch v, ok := d.GetOk(dbTablespaceAttr); {
+	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
+		fmt.Fprint(b, " TABLESPACE DEFAULT")
+	case ok:
 		fmt.Fprint(b, " TABLESPACE ", pq.QuoteIdentifier(v.(string)))
 	}
 

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -86,6 +86,27 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 						"postgresql_database.pathological_opts", "allow_connections", "true"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pathological_opts", "is_template", "true"),
+
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pg_default_opts", "owner", "myrole"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pg_default_opts", "name", "pg_defaults_db"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pg_default_opts", "template", "DEFAULT"),
+					// resource.TestCheckResourceAttr(
+					// 	"postgresql_database.pg_default_opts", "encoding", "DEFAULT"),
+					// resource.TestCheckResourceAttr(
+					// 	"postgresql_database.pg_default_opts", "lc_collate", "DEFAULT"),
+					// resource.TestCheckResourceAttr(
+					//  "postgresql_database.pg_default_opts", "lc_ctype", "DEFAULT"),
+					// resource.TestCheckResourceAttr(
+					// 	"postgresql_database.pg_default_opts", "tablespace_name", "DEFAULT"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pg_default_opts", "connection_limit", "0"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pg_default_opts", "allow_connections", "true"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.pg_default_opts", "is_template", "true"),
 				),
 			},
 		},
@@ -229,6 +250,29 @@ resource "postgresql_database" "pathological_opts" {
    lc_collate = "C"
    lc_ctype = "C"
    tablespace_name = "pg_default"
+   connection_limit = 0
+   allow_connections = true
+   is_template = true
+}
+
+resource "postgresql_database" "pg_default_opts" {
+  lifecycle {
+    ignore_changes = [
+      "template",
+      "encoding",
+      "lc_collate",
+      "lc_ctype",
+      "tablespace_name",
+    ]
+  }
+
+   name = "pg_defaults_db"
+   owner = "${postgresql_role.myrole.name}"
+   template = "DEFAULT"
+   encoding = "DEFAULT"
+   lc_collate = "DEFAULT"
+   lc_ctype = "DEFAULT"
+   tablespace_name = "DEFAULT"
    connection_limit = 0
    allow_connections = true
    is_template = true


### PR DESCRIPTION
Use of `DEFAULT` is problematic because the user is specifying a value which
defeats the Terraform `Computed` resource attribute.  A byproduct of this
is that use of `DEFAULT` can not be used without adding lifecycle attribute
otherwise the plan never converges.

```
resource "postgresql_database" "pg_default_opts" {
  lifecycle {
    ignore_changes = [
      "template",
      "encoding",
      "lc_collate",
      "lc_ctype",
      "tablespace_name",
    ]
  }
  # snip
}
```

Fixes: #9