### PR TITLE
Mark `ssl_mode` as the deprecated spelling of `sslmode`.

### DIFF
--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -121,7 +121,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if sslModeRaw, ok := d.GetOk("sslmode"); ok {
 		sslMode = sslModeRaw.(string)
 	} else {
-		sslMode = d.Get("ssl_mode").(string)
+		sslModeDeprecated := d.Get("ssl_mode").(string)
+		if sslModeDeprecated != "" {
+			sslMode = sslModeDeprecated
+		}
 	}
 	versionStr := d.Get("expected_version").(string)
 	version, _ := semver.Parse(versionStr)


### PR DESCRIPTION
The docs have long since been updated to use the `sslmode` spelling.