### PR TITLE
Allow connection strings in provider

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -1,7 +1,10 @@
 package postgresql
 
 import (
+	"errors"
 	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -21,4 +24,78 @@ func validateConnLimit(v interface{}, key string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("%s can not be less than -1", key))
 	}
 	return
+}
+
+// libPQ style connection strings are:
+// postgresql://[user[:password]@][netloc][:port][,...][/dbname][?param1=value1&...]
+// The only param we care about is sslMode
+type postgresConnString struct {
+	username string
+	password string
+	netloc   string
+	port     int
+	dbname   string
+	sslmode  string
+}
+
+func parseConnectionString(connString string) (postgresConnString, error) {
+	url, err := url.Parse(connString)
+
+	if err != nil {
+		return postgresConnString{}, err
+	}
+
+	if url.Scheme != "postgres" && url.Scheme != "postgresql" {
+		return postgresConnString{}, errors.New("Not a PostgreSQL URL")
+	}
+
+	username, password := usernameAndPasswordFromURL(url)
+	netloc, port := hostAndPortFromURL(url)
+	dbname := dbnameFromURL(url)
+	sslmode := sslmodeFromURL(url)
+
+	r := postgresConnString{username, password, netloc, port, dbname, sslmode}
+
+	return r, nil
+}
+
+func usernameAndPasswordFromURL(url *url.URL) (string, string) {
+	var username string
+	var password string
+
+	if url.User != nil {
+		username = url.User.Username()
+		password, _ = url.User.Password()
+	}
+
+	return username, password
+}
+
+func sslmodeFromURL(url *url.URL) string {
+	var sslmode string
+
+	queryVals := url.Query()
+
+	if len(queryVals["sslmode"]) == 1 {
+		sslmode = queryVals["sslmode"][0]
+	}
+
+	return sslmode
+}
+
+func hostAndPortFromURL(url *url.URL) (string, int) {
+	parts := strings.Split(url.Host, ":")
+
+	if len(parts) == 1 {
+		return parts[0], 0
+	} else {
+		port, _ := strconv.Atoi(parts[1])
+		return parts[0], port
+	}
+}
+
+func dbnameFromURL(url *url.URL) string {
+	path := url.Path
+
+	return strings.TrimPrefix(path, "/")
 }

--- a/postgresql/helpers_test.go
+++ b/postgresql/helpers_test.go
@@ -1,0 +1,58 @@
+package postgresql
+
+import (
+	"testing"
+)
+
+func TestBadURL(t *testing.T) {
+	_, err := parseConnectionString("test")
+
+	if err == nil {
+		t.Error("Expected bad URL to return error")
+	}
+}
+
+func TestBadScheme(t *testing.T) {
+	_, err := parseConnectionString("notpostgres://test")
+
+	if err == nil {
+		t.Error("Expected bad schema to return error")
+	}
+}
+
+func TestURLParsing(t *testing.T) {
+	expectations := map[string]postgresConnString{
+		"postgres://testhost/testdb": postgresConnString{
+			netloc: "testhost", dbname: "testdb",
+		},
+		"postgresql://testhost/testdb": postgresConnString{
+			netloc: "testhost", dbname: "testdb",
+		},
+		"postgres://testhost": postgresConnString{netloc: "testhost"},
+		"postgres://user@testhost": postgresConnString{
+			netloc: "testhost", username: "user",
+		},
+		"postgres://user:pass@testhost": postgresConnString{
+			netloc: "testhost", username: "user", password: "pass",
+		},
+		"postgres://testhost:1234": postgresConnString{
+			netloc: "testhost", port: 1234,
+		},
+		"postgres://user:pass@testhost:1234/dbname": postgresConnString{
+			netloc: "testhost", port: 1234, username: "user", password: "pass",
+			dbname: "dbname",
+		},
+	}
+
+	for k, v := range expectations {
+		result, err := parseConnectionString(k)
+
+		if err != nil {
+			t.Error("Unexpected error parsing ", k)
+		}
+
+		if v != result {
+			t.Error("Unexpected result parsing ", k, v, result)
+		}
+	}
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -26,6 +26,15 @@ provider "postgresql" {
 }
 ```
 
+or
+
+```hcl
+provider "postgresql" {
+  connection_string = "postgres://postgres_user:postgres_password@postgres_server_ip:5432/postgres?sslmode=require"
+  connect_timeout = 15
+}
+```
+
 Configuring multiple servers can be done by specifying the alias option.
 
 ```hcl
@@ -58,7 +67,7 @@ resource "postgresql_database" "my_db2" {
 
 The following arguments are supported:
 
-* `host` - (Required) The address for the postgresql server connection.
+* `host` - (Required unless `connection_string` is provided) The address for the postgresql server connection.
 * `port` - (Optional) The port for the postgresql server connection. The default is `5432`.
 * `database` - (Optional) Database to connect to. The default is `postgres`.
 * `username` - (Required) Username for the server connection.
@@ -83,3 +92,4 @@ The following arguments are supported:
   Version](https://www.postgresql.org/support/versioning/) or `current`.  Once a
   connection has been established, Terraform will fingerprint the actual
   version.  Default: `9.0.0`.
+* `connection_string` - (Required unless `host` is provided) The libPQ style connection string for the postgres server connection


### PR DESCRIPTION
We typically expose our Postgres connections as libPQ style connection strings (e.g. `postgres://user:pass@host:port/db`). Rather than atomise these for use in the provider, it would be great if the provider could optionally connect via these strings rather than individual connection parameters.

These patches enable that. There don't seem to be underlying tests for the actual provider; if there are, and I've missed them, I'll gladly update them to account for the connection string support. Of course, any other feedback is most welcome as well.