### PR TITLE
Create new resource: postgresql_grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.3.0 (Unreleased)
+
+FEATURES:
+
+* New resource: postgresql_grant. This resource allows to grant privileges on all existing tables or sequences for a specified role in a specified schema.
+  ([#51](https://github.com/terraform-providers/terraform-provider-postgresql/pull/51))
+
+
 ## 0.2.1 (Unreleased)
 BUG FIXES:
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -72,7 +72,6 @@ var (
 type Config struct {
 	Host              string
 	Port              int
-	Database          string
 	Username          string
 	Password          string
 	DatabaseUsername  string
@@ -90,6 +89,8 @@ type Client struct {
 	// Configuration for the client
 	config Config
 
+	databaseName string
+
 	// db is a pointer to the DB connection.  Callers are responsible for
 	// releasing their connections.
 	db *sql.DB
@@ -106,12 +107,12 @@ type Client struct {
 	catalogLock sync.RWMutex
 }
 
-// NewClient returns new client config
-func (c *Config) NewClient() (*Client, error) {
+// NewClient returns client config for the specified database.
+func (c *Config) NewClient(database string) (*Client, error) {
 	dbRegistryLock.Lock()
 	defer dbRegistryLock.Unlock()
 
-	dsn := c.connStr()
+	dsn := c.connStr(database)
 	dbEntry, found := dbRegistry[dsn]
 	if !found {
 		db, err := sql.Open("postgres", dsn)
@@ -119,8 +120,10 @@ func (c *Config) NewClient() (*Client, error) {
 			return nil, errwrap.Wrapf("Error connecting to PostgreSQL server: {{err}}", err)
 		}
 
-		// only one connection
-		db.SetMaxIdleConns(1)
+		// We don't want to retain connection
+		// So when we connect on a specific database which might be managed by terraform,
+		// we don't keep opened connection in case of the db has to be dopped in the plan.
+		db.SetMaxIdleConns(0)
 		db.SetMaxOpenConns(c.MaxConns)
 
 		version, err := fingerprintCapabilities(db)
@@ -137,9 +140,10 @@ func (c *Config) NewClient() (*Client, error) {
 	}
 
 	client := Client{
-		config:  *c,
-		db:      dbEntry.db,
-		version: dbEntry.version,
+		config:       *c,
+		databaseName: database,
+		db:           dbEntry.db,
+		version:      dbEntry.version,
 	}
 
 	return &client, nil
@@ -158,7 +162,7 @@ func (c *Config) featureSupported(name featureName) bool {
 	return fn(c.ExpectedVersion)
 }
 
-func (c *Config) connStr() string {
+func (c *Config) connStr(database string) string {
 	// NOTE: dbname must come before user otherwise dbname will be set to
 	// user.
 	var dsnFmt string
@@ -213,7 +217,7 @@ func (c *Config) connStr() string {
 		logValues := []interface{}{
 			quote(c.Host),
 			c.Port,
-			quote(c.Database),
+			quote(database),
 			quote(c.Username),
 			quote("<redacted>"),
 			quote(c.SSLMode),
@@ -232,7 +236,7 @@ func (c *Config) connStr() string {
 		connValues := []interface{}{
 			quote(c.Host),
 			c.Port,
-			quote(c.Database),
+			quote(database),
 			quote(c.Username),
 			quote(c.Password),
 			quote(c.SSLMode),

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -104,6 +104,7 @@ func Provider() terraform.ResourceProvider {
 			"postgresql_extension": resourcePostgreSQLExtension(),
 			"postgresql_schema":    resourcePostgreSQLSchema(),
 			"postgresql_role":      resourcePostgreSQLRole(),
+			"postgresql_grant":     resourcePostgreSQLGrant(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -149,7 +150,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Host:              d.Get("host").(string),
 		Port:              d.Get("port").(int),
-		Database:          d.Get("database").(string),
 		Username:          d.Get("username").(string),
 		Password:          d.Get("password").(string),
 		DatabaseUsername:  d.Get("database_username").(string),
@@ -161,7 +161,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ExpectedVersion:   version,
 	}
 
-	client, err := config.NewClient()
+	client, err := config.NewClient(d.Get("database").(string))
 	if err != nil {
 		return nil, errwrap.Wrapf("Error initializing PostgreSQL client: {{err}}", err)
 	}

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -189,7 +189,7 @@ func TestAccPostgresqlDatabase_GrantOwner(t *testing.T) {
 	skipIfNotAcc(t)
 
 	config := getTestConfig(t)
-	dsn := config.connStr()
+	dsn := config.connStr("postgres")
 
 	var stateConfig = `
 resource postgresql_role "test_owner" {
@@ -226,7 +226,7 @@ func TestAccPostgresqlDatabase_GrantOwnerNotNeeded(t *testing.T) {
 	skipIfNotAcc(t)
 
 	config := getTestConfig(t)
-	dsn := config.connStr()
+	dsn := config.connStr("postgres")
 
 	dbExecute(
 		t, dsn,

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -1,0 +1,303 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	// Use Postgres as SQL driver
+	"github.com/lib/pq"
+)
+
+var objectTypes = map[string]string{
+	"table":    "r",
+	"sequence": "S",
+}
+
+func resourcePostgreSQLGrant() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePostgreSQLGrantCreate,
+		// As create revokes and grants we can use it to update too
+		Update: resourcePostgreSQLGrantCreate,
+		Read:   resourcePostgreSQLGrantRead,
+		Delete: resourcePostgreSQLGrantDelete,
+
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the role to grant privileges on",
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database to grant privileges on for this role",
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database schema to grant privileges on for this role",
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"table",
+					"sequence",
+				}, false),
+				Description: "The PostgreSQL object type to grant the privileges on (one of: table, sequence)",
+			},
+			"privileges": &schema.Schema{
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				MinItems:    1,
+				Description: "The list of privileges to grant",
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLGrantRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	client.catalogLock.RLock()
+	defer client.catalogLock.RUnlock()
+
+	exists, err := checkRoleDBSchemaExists(client, d)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(generateGrantID(d))
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	return readRolePrivileges(txn, d)
+}
+
+func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) error {
+	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+		return err
+	}
+
+	database := d.Get("database").(string)
+
+	client := meta.(*Client)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	// Revoke all privileges before granting otherwise reducing privileges will not work.
+	// We just have to revoke them in the same transaction so the role will not lost its
+	// privileges between the revoke and grant statements.
+	if err = revokeRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = grantRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return errwrap.Wrapf("could not commit transaction: {{err}}", err)
+	}
+
+	d.SetId(generateGrantID(d))
+
+	txn, err = startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	return readRolePrivileges(txn, d)
+}
+
+func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	if err = revokeRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return errwrap.Wrapf("could not commit transaction: {{err}}", err)
+	}
+
+	return nil
+}
+
+func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	// This returns, for the specified role (rolname),
+	// the list of all object of the specified type (relkind) in the specified schema (namespace)
+	// with the list of the currently applied privileges (aggregation of privilege_type)
+	//
+	// Our goal is to check that every object has the same privileges as saved in the state.
+	query := `
+SELECT pg_class.relname, array_remove(array_agg(privilege_type), NULL)
+FROM pg_class
+JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+LEFT JOIN (
+    SELECT acls.* FROM (
+        SELECT relname, relnamespace, relkind, (aclexplode(relacl)).* FROM pg_class c
+    ) as acls
+    JOIN pg_roles on grantee = pg_roles.oid
+    WHERE rolname=$1
+) privs
+USING (relname, relnamespace, relkind)
+WHERE nspname = $2 AND relkind = $3
+GROUP BY pg_class.relname;
+`
+
+	objectType := d.Get("object_type").(string)
+	rows, err := txn.Query(
+		query, d.Get("role"), d.Get("schema"), objectTypes[objectType],
+	)
+	if err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var objName string
+		var privileges pq.ByteaArray
+
+		if err := rows.Scan(&objName, &privileges); err != nil {
+			return err
+		}
+		privilegesSet := pgArrayToSet(privileges)
+
+		if !privilegesSet.Equal(d.Get("privileges").(*schema.Set)) {
+			// If any object doesn't have the same privileges as saved in the state,
+			// we return an empty privileges to force an update.
+			log.Printf(
+				"[DEBUG] %s %s has not the expected privileges %v for role %s",
+				strings.ToTitle(objectType), objName, privileges, d.Get("role"),
+			)
+			d.Set("privileges", schema.NewSet(schema.HashString, []interface{}{}))
+			break
+		}
+
+	}
+
+	return nil
+}
+
+func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	privileges := []string{}
+	for _, priv := range d.Get("privileges").(*schema.Set).List() {
+		privileges = append(privileges, priv.(string))
+	}
+
+	query := fmt.Sprintf(
+		"GRANT %s ON ALL %sS IN SCHEMA %s TO %s",
+		strings.Join(privileges, ","),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := fmt.Sprintf(
+		"REVOKE ALL PRIVILEGES ON ALL %sS IN SCHEMA %s FROM %s",
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, error) {
+	txn, err := startTransaction(client, "")
+	if err != nil {
+		return false, err
+	}
+	defer deferredRollback(txn)
+
+	// Check the role exists
+	role := d.Get("role").(string)
+	exists, err := roleExists(txn, role)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] role %s does not exists", role)
+		return false, nil
+	}
+
+	// Check the database exists
+	database := d.Get("database").(string)
+	exists, err = dbExists(txn, database)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] database %s does not exists", database)
+		return false, nil
+	}
+
+	// Connect on this database to check if schema exists
+	dbTxn, err := startTransaction(client, database)
+	if err != nil {
+		return false, err
+	}
+	defer dbTxn.Rollback()
+
+	// Check the schema exists (the SQL connection needs to be on the right database)
+	pgSchema := d.Get("schema").(string)
+	exists, err = schemaExists(txn, pgSchema)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] schema %s does not exists", pgSchema)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func generateGrantID(d *schema.ResourceData) string {
+	return strings.Join([]string{
+		d.Get("role").(string), d.Get("database").(string),
+		d.Get("schema").(string), d.Get("object_type").(string),
+	}, "_")
+}

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -1,0 +1,67 @@
+package postgresql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPostgresqlGrant(t *testing.T) {
+	// We have to create the database outside of resource.Test
+	// because we need to create a table to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true, true)
+	defer teardown()
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+	var testGrantSelect = fmt.Sprintf(`
+	resource "postgresql_grant" "test_ro" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT"]
+	}
+	`, dbName, roleName)
+
+	var testGrantSelectInsertUpdate = fmt.Sprintf(`
+	resource "postgresql_grant" "test_ro" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT", "INSERT", "UPDATE"]
+	}
+	`, dbName, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGrantSelect,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT"}, false)
+					},
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+				),
+			},
+			{
+				Config: testGrantSelectInsertUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT", "INSERT", "UPDATE"}, false)
+					},
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "3"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.892623219", "INSERT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.1759376126", "UPDATE"),
+				),
+			},
+		},
+	})
+}

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -266,7 +266,7 @@ func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	roleName := d.Get(roleNameAttr).(string)
 

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -162,7 +162,7 @@ func testAccCheckRoleCanLogin(t *testing.T, role, password string) resource.Test
 		config := getTestConfig(t)
 		config.Username = role
 		config.Password = password
-		db, err := sql.Open("postgres", config.connStr())
+		db, err := sql.Open("postgres", config.connStr("postgres"))
 		if err != nil {
 			return fmt.Errorf("could not open SQL connection: %v", err)
 		}

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -162,7 +162,7 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	for _, query := range queries {
 		if _, err = txn.Exec(query); err != nil {
@@ -188,7 +188,7 @@ func resourcePostgreSQLSchemaDelete(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	schemaName := d.Get(schemaNameAttr).(string)
 
@@ -286,7 +286,7 @@ func resourcePostgreSQLSchemaUpdate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	if err := setSchemaName(txn, d); err != nil {
 		return err

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -37,7 +39,6 @@ func getTestConfig(t *testing.T) Config {
 		Port:     dbPort,
 		Username: getEnv("PGUSER", ""),
 		Password: getEnv("PGPASSWORD", ""),
-		Database: getEnv("PGDATABASE", "postgres"),
 		SSLMode:  getEnv("PGSSLMODE", ""),
 	}
 }
@@ -62,4 +63,95 @@ func dbExecute(t *testing.T, dsn, query string, args ...interface{}) {
 	if _, err = db.Exec(query, args...); err != nil {
 		t.Fatalf("could not execute query %s: %v", query, err)
 	}
+}
+
+func getTestDBNames(dbSuffix string) (dbName string, roleName string) {
+	dbName = fmt.Sprintf("%s_%s", dbNamePrefix, dbSuffix)
+	roleName = fmt.Sprintf("%s_%s", roleNamePrefix, dbSuffix)
+
+	return
+}
+
+// setupTestDatabase creates all needed resources before executing a terraform test
+// and provides the teardown function to delete all these resources.
+func setupTestDatabase(t *testing.T, createDB, createRole, createTable bool) (string, func()) {
+	config := getTestConfig(t)
+
+	suffix := strconv.Itoa(int(time.Now().UnixNano()))
+
+	dbName, roleName := getTestDBNames(suffix)
+
+	if createDB {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("CREATE DATABASE %s", dbName))
+	}
+	if createRole {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf(
+			"CREATE ROLE %s LOGIN ENCRYPTED PASSWORD '%s'",
+			roleName, testRolePassword,
+		))
+	}
+
+	if createTable {
+		// Create a test table in this new database
+		dbExecute(t, config.connStr(dbName), testTableDef)
+	}
+
+	return suffix, func() {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("DROP ROLE IF EXISTS %s", roleName))
+	}
+}
+
+func testCheckTablePrivileges(
+	t *testing.T, dbSuffix string, allowedPrivileges []string, createTable bool,
+) error {
+	config := getTestConfig(t)
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	// Some test (e.g.: default privileges) need the test table to be created only now
+	if createTable {
+		db, err := sql.Open("postgres", config.connStr(dbName))
+		if err != nil {
+			t.Fatalf("could not open connection pool for db %s: %v", dbName, err)
+		}
+		defer db.Close()
+
+		if _, err := db.Exec(testTableDef); err != nil {
+			t.Fatalf("could not create test table in db %s: %v", dbName, err)
+		}
+		// In this case we need to drop table after each test.
+		defer func() {
+			db.Exec("DROP TABLE test_table")
+		}()
+	}
+
+	// Connect as the test role
+	config.Username = roleName
+	config.Password = testRolePassword
+
+	db, err := sql.Open("postgres", config.connStr(dbName))
+	if err != nil {
+		t.Fatalf("could not open connection pool for db %s: %v", dbName, err)
+	}
+	defer db.Close()
+
+	queries := map[string]string{
+		"SELECT": "SELECT count(*) FROM test_table",
+		"INSERT": "INSERT INTO test_table VALUES ('test')",
+		"UPDATE": "UPDATE test_table SET val = 'test'",
+		"DELETE": "DELETE FROM test_table",
+	}
+
+	for queryType, query := range queries {
+		_, err := db.Exec(query)
+
+		if err != nil && sliceContainsStr(allowedPrivileges, queryType) {
+			return errwrap.Wrapf(fmt.Sprintf("could not %s on test table: {{err}}", queryType), err)
+
+		} else if err == nil && !sliceContainsStr(allowedPrivileges, queryType) {
+			return errwrap.Wrapf(fmt.Sprintf("%s did not failed as expected: {{err}}", queryType), err)
+		}
+	}
+	return nil
 }

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,146 @@
+package validation
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}


### PR DESCRIPTION
This resource allows to grant privileges on all existing tables or sequences for a specified role in a specified schema.

This fix #29 

Example:

```hcl
resource postgresql_grant "readonly_tables" {
  database    = "test_db"
  role        = "test_role"
  schema      = "public"
  object_type = "table"
  privileges  = ["SELECT"]
}
```

Hi there (cc @apparentlymart ),

We started to use this provider to manage our Postgresql databases/credentials. As its current state is quite buggy and there's several useful resources missing, we started to develop it to adapt to our needs.

We saw that the Terraform team at HashiCorp does not develop on it anymore and there's also multiple open PRs so I'm not even sure you are able to take time to review/merge community PRs.

We'll open all our PRs anyway so, in the worst case, it could at least be useful to other people with the same needs.

Thanks.