### PR TITLE
postgresql_role: Add roles attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ FEATURES:
   ([#53](https://github.com/terraform-providers/terraform-provider-postgresql/pull/53))
 * New resource: postgresql_default_privileges. This resource allow to manage default privileges for tables or sequences for a specified role in a specified schema.
   ([#53](https://github.com/terraform-providers/terraform-provider-postgresql/pull/53))
+* `postgresql_role`: Add `roles` attribute.
+  ([#52](https://github.com/terraform-providers/terraform-provider-postgresql/pull/52))
 
 BUG FIXES:
 

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -85,6 +85,8 @@ resource "postgresql_role" "my_replication_role" {
 * `password` - (Optional) Sets the role's password. A password is only of use
   for roles having the `login` attribute set to true.
 
+* `roles` - (Optional) Defines list of roles which will be granted to this new role.
+
 * `valid_until` - (Optional) Defines the date and time after which the role's
   password is no longer valid.  Established connections past this `valid_time`
   will have to be manually terminated.  This value corresponds to a PostgreSQL


### PR DESCRIPTION
This allows to grant roles to the role we are managing.

Example:

```hcl
resource postgresql_role "test_group" {
  name = "test_group"
}

resource postgresql_role "test_role" {
  name  = "test_role"
  roles = ["${postgresql_role.test_group.name}"]
}
```

Fix #21 

This probably conflicts with #23