### PR TITLE
New resources: postgresql_grant & postgresql_default_privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
-## 0.2.2 (Unreleased)
+### 0.3.0 (Unreleased)
+
+FEATURES:
+
+* New resource: postgresql_grant. This resource allows to grant privileges on all existing tables or sequences for a specified role in a specified schema.
+  ([#53](https://github.com/terraform-providers/terraform-provider-postgresql/pull/53))
 
 ## 0.2.1 (February 28, 2019)
+
 BUG FIXES:
 
 * `provider`: Add a `superuser` setting to fix role password update when provider is not connected as a superuser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ FEATURES:
 
 * New resource: postgresql_grant. This resource allows to grant privileges on all existing tables or sequences for a specified role in a specified schema.
   ([#53](https://github.com/terraform-providers/terraform-provider-postgresql/pull/53))
+* New resource: postgresql_default_privileges. This resource allow to manage default privileges for tables or sequences for a specified role in a specified schema.
+  ([#53](https://github.com/terraform-providers/terraform-provider-postgresql/pull/53))
 
 ## 0.2.1 (February 28, 2019)
 

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -100,11 +100,12 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"postgresql_database":  resourcePostgreSQLDatabase(),
-			"postgresql_extension": resourcePostgreSQLExtension(),
-			"postgresql_schema":    resourcePostgreSQLSchema(),
-			"postgresql_role":      resourcePostgreSQLRole(),
-			"postgresql_grant":     resourcePostgreSQLGrant(),
+			"postgresql_database":           resourcePostgreSQLDatabase(),
+			"postgresql_default_privileges": resourcePostgreSQLDefaultPrivileges(),
+			"postgresql_extension":          resourcePostgreSQLExtension(),
+			"postgresql_grant":              resourcePostgreSQLGrant(),
+			"postgresql_schema":             resourcePostgreSQLSchema(),
+			"postgresql_role":               resourcePostgreSQLRole(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -104,6 +104,7 @@ func Provider() terraform.ResourceProvider {
 			"postgresql_extension": resourcePostgreSQLExtension(),
 			"postgresql_schema":    resourcePostgreSQLSchema(),
 			"postgresql_role":      resourcePostgreSQLRole(),
+			"postgresql_grant":     resourcePostgreSQLGrant(),
 		},
 
 		ConfigureFunc: providerConfigure,
@@ -149,7 +150,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Host:              d.Get("host").(string),
 		Port:              d.Get("port").(int),
-		Database:          d.Get("database").(string),
 		Username:          d.Get("username").(string),
 		Password:          d.Get("password").(string),
 		DatabaseUsername:  d.Get("database_username").(string),
@@ -161,7 +161,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ExpectedVersion:   version,
 	}
 
-	client, err := config.NewClient()
+	client, err := config.NewClient(d.Get("database").(string))
 	if err != nil {
 		return nil, errwrap.Wrapf("Error initializing PostgreSQL client: {{err}}", err)
 	}

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -189,7 +189,7 @@ func TestAccPostgresqlDatabase_GrantOwner(t *testing.T) {
 	skipIfNotAcc(t)
 
 	config := getTestConfig(t)
-	dsn := config.connStr()
+	dsn := config.connStr("postgres")
 
 	var stateConfig = `
 resource postgresql_role "test_owner" {
@@ -226,7 +226,7 @@ func TestAccPostgresqlDatabase_GrantOwnerNotNeeded(t *testing.T) {
 	skipIfNotAcc(t)
 
 	config := getTestConfig(t)
-	dsn := config.connStr()
+	dsn := config.connStr("postgres")
 
 	dbExecute(
 		t, dsn,

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -1,0 +1,248 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	// Use Postgres as SQL driver
+	"github.com/lib/pq"
+)
+
+func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePostgreSQLDefaultPrivilegesCreate,
+		Update: resourcePostgreSQLDefaultPrivilegesCreate,
+		Read:   resourcePostgreSQLDefaultPrivilegesRead,
+		Delete: resourcePostgreSQLDefaultPrivilegesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the role to which grant default privileges on",
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database to grant default privileges for this role",
+			},
+			"owner": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Role for which apply default privileges (You can change default privileges only for objects that will be created by yourself or by roles that you are a member of)",
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database schema to set default privileges for this role",
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"table",
+					"sequence",
+				}, false),
+				Description: "The PostgreSQL object type to set the default privileges on (one of: table, sequence)",
+			},
+			"privileges": &schema.Schema{
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				MinItems:    1,
+				Description: "The list of privileges to apply as default privileges",
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLDefaultPrivilegesRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	client.catalogLock.RLock()
+	defer client.catalogLock.RUnlock()
+
+	exists, err := checkRoleDBSchemaExists(client, d)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	return readRoleDefaultPrivileges(txn, d)
+}
+
+func resourcePostgreSQLDefaultPrivilegesCreate(d *schema.ResourceData, meta interface{}) error {
+	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+		return err
+	}
+
+	database := d.Get("database").(string)
+
+	client := meta.(*Client)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	// Revoke all privileges before granting otherwise reducing privileges will not work.
+	// We just have to revoke them in the same transaction so role will not lost his privileges between revoke and grant.
+	if err = revokeRoleDefaultPrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = grantRoleDefaultPrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err := txn.Commit(); err != nil {
+		return err
+	}
+
+	d.SetId(generateDefaultPrivilegesID(d))
+
+	txn, err = startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	return readRoleDefaultPrivileges(txn, d)
+}
+
+func resourcePostgreSQLDefaultPrivilegesDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	revokeRoleDefaultPrivileges(txn, d)
+	if err := txn.Commit(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	role := d.Get("role").(string)
+	owner := d.Get("owner").(string)
+	pgSchema := d.Get("schema").(string)
+	objectType := d.Get("object_type").(string)
+
+	// This query aggregates the list of default privileges type (prtype)
+	// for the role (grantee), owner (grantor), schema (namespace name)
+	// and the specified object type (defaclobjtype).
+	query := `SELECT array_agg(prtype) FROM (
+		SELECT defaclnamespace, (aclexplode(defaclacl)).* FROM pg_default_acl
+		WHERE defaclobjtype = $3
+	) AS t (namespace, grantor_oid, grantee_oid, prtype, grantable)
+
+	JOIN pg_namespace ON pg_namespace.oid = namespace
+	WHERE pg_get_userbyid(grantee_oid) = $1 AND nspname = $2 AND pg_get_userbyid(grantor_oid) = $4;
+`
+	var privileges pq.ByteaArray
+
+	if err := txn.QueryRow(
+		query, role, pgSchema, objectTypes[objectType], owner,
+	).Scan(&privileges); err != nil {
+		return errwrap.Wrapf("could not read default privileges: {{err}}", err)
+	}
+
+	// We consider no privileges as "not exists"
+	if len(privileges) == 0 {
+		log.Printf("[DEBUG] no default privileges for role %s in schema %s", role, pgSchema)
+		d.SetId("")
+		return nil
+	}
+
+	privilegesSet := pgArrayToSet(privileges)
+	d.Set("privileges", privilegesSet)
+	d.SetId(generateDefaultPrivilegesID(d))
+
+	return nil
+}
+
+func grantRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	role := d.Get("role").(string)
+	pgSchema := d.Get("schema").(string)
+
+	privileges := []string{}
+	for _, priv := range d.Get("privileges").(*schema.Set).List() {
+		privileges = append(privileges, priv.(string))
+	}
+
+	// TODO: We grant default privileges for the DB owner
+	// For that we need to be either superuser or a member of the owner role.
+	// With AWS RDS, It's not possible to create superusers as it is restricted by AWS itself.
+	// In that case, the only solution would be to have the PostgreSQL user used by Terraform
+	// to be also part of the database owner role.
+
+	query := fmt.Sprintf("ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s GRANT %s ON %sS TO %s",
+		pq.QuoteIdentifier(d.Get("owner").(string)),
+		pq.QuoteIdentifier(pgSchema),
+		strings.Join(privileges, ","),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(role),
+	)
+
+	_, err := txn.Exec(
+		query,
+	)
+	if err != nil {
+		return errwrap.Wrapf("could not alter default privileges: {{err}}", err)
+	}
+
+	return nil
+}
+
+func revokeRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := fmt.Sprintf(
+		"ALTER DEFAULT PRIVILEGES FOR ROLE %s IN SCHEMA %s REVOKE ALL ON %sS FROM %s",
+		pq.QuoteIdentifier(d.Get("owner").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func generateDefaultPrivilegesID(d *schema.ResourceData) string {
+	return strings.Join([]string{
+		d.Get("role").(string), d.Get("database").(string), d.Get("schema").(string),
+		d.Get("owner").(string), d.Get("object_type").(string),
+	}, "_")
+}

--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -1,0 +1,59 @@
+package postgresql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPostgresqlDefaultPrivileges(t *testing.T) {
+	// We have to create the database outside of resource.Test
+	// because we need to create a table to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	config := getTestConfig(t)
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	// We set PGUSER as owner as he will create the test table
+	var testDPSelect = fmt.Sprintf(`
+	resource "postgresql_default_privileges" "test_ro" {
+		database    = "%s"
+		owner       = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT"]
+	}
+	`, dbName, config.Username, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testDPSelect,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						tables := []string{"test_table"}
+						// To test default privileges, we need to create a table
+						// after having apply the state.
+						dropFunc := createTestTables(t, dbSuffix, tables)
+						defer dropFunc()
+
+						return testCheckTablesPrivileges(t, dbSuffix, tables, []string{"SELECT"})
+					},
+					resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "object_type", "table"),
+					resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_default_privileges.test_ro", "privileges.3138006342", "SELECT"),
+				),
+			},
+		},
+	})
+}

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -9,18 +9,11 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func testCheckCompatibleVersion(t *testing.T) {
-	client := testAccProvider.Meta().(*Client)
-	if !client.featureSupported(featureExtension) {
-		t.Skip(fmt.Sprintf("Skip extension tests for Postgres %s", client.version))
-	}
-}
-
 func TestAccPostgresqlExtension_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testCheckCompatibleVersion(t)
+			testCheckCompatibleVersion(t, featureExtension)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
@@ -96,7 +89,7 @@ func TestAccPostgresqlExtension_SchemaRename(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testCheckCompatibleVersion(t)
+			testCheckCompatibleVersion(t, featureExtension)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -1,0 +1,324 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	// Use Postgres as SQL driver
+	"github.com/lib/pq"
+)
+
+var objectTypes = map[string]string{
+	"table":    "r",
+	"sequence": "S",
+}
+
+func resourcePostgreSQLGrant() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePostgreSQLGrantCreate,
+		// As create revokes and grants we can use it to update too
+		Update: resourcePostgreSQLGrantCreate,
+		Read:   resourcePostgreSQLGrantRead,
+		Delete: resourcePostgreSQLGrantDelete,
+
+		Schema: map[string]*schema.Schema{
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the role to grant privileges on",
+			},
+			"database": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database to grant privileges on for this role",
+			},
+			"schema": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The database schema to grant privileges on for this role",
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"table",
+					"sequence",
+				}, false),
+				Description: "The PostgreSQL object type to grant the privileges on (one of: table, sequence)",
+			},
+			"privileges": &schema.Schema{
+				Type:        schema.TypeSet,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				MinItems:    1,
+				Description: "The list of privileges to grant",
+			},
+		},
+	}
+}
+
+func resourcePostgreSQLGrantRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	if !client.featureSupported(featurePrivileges) {
+		return fmt.Errorf(
+			"postgresql_grant resource is not supported for this Postgres version (%s)",
+			client.version,
+		)
+	}
+
+	client.catalogLock.RLock()
+	defer client.catalogLock.RUnlock()
+
+	exists, err := checkRoleDBSchemaExists(client, d)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
+	}
+	d.SetId(generateGrantID(d))
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	return readRolePrivileges(txn, d)
+}
+
+func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	if !client.featureSupported(featurePrivileges) {
+		return fmt.Errorf(
+			"postgresql_grant resource is not supported for this Postgres version (%s)",
+			client.version,
+		)
+	}
+
+	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+		return err
+	}
+
+	database := d.Get("database").(string)
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	// Revoke all privileges before granting otherwise reducing privileges will not work.
+	// We just have to revoke them in the same transaction so the role will not lost its
+	// privileges between the revoke and grant statements.
+	if err = revokeRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = grantRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return errwrap.Wrapf("could not commit transaction: {{err}}", err)
+	}
+
+	d.SetId(generateGrantID(d))
+
+	txn, err = startTransaction(client, database)
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	return readRolePrivileges(txn, d)
+}
+
+func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	if !client.featureSupported(featurePrivileges) {
+		return fmt.Errorf(
+			"postgresql_grant resource is not supported for this Postgres version (%s)",
+			client.version,
+		)
+	}
+
+	client.catalogLock.Lock()
+	defer client.catalogLock.Unlock()
+
+	txn, err := startTransaction(client, d.Get("database").(string))
+	if err != nil {
+		return err
+	}
+	defer deferredRollback(txn)
+
+	if err = revokeRolePrivileges(txn, d); err != nil {
+		return err
+	}
+
+	if err = txn.Commit(); err != nil {
+		return errwrap.Wrapf("could not commit transaction: {{err}}", err)
+	}
+
+	return nil
+}
+
+func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	// This returns, for the specified role (rolname),
+	// the list of all object of the specified type (relkind) in the specified schema (namespace)
+	// with the list of the currently applied privileges (aggregation of privilege_type)
+	//
+	// Our goal is to check that every object has the same privileges as saved in the state.
+	query := `
+SELECT pg_class.relname, array_remove(array_agg(privilege_type), NULL)
+FROM pg_class
+JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+LEFT JOIN (
+    SELECT acls.* FROM (
+        SELECT relname, relnamespace, relkind, (aclexplode(relacl)).* FROM pg_class c
+    ) as acls
+    JOIN pg_roles on grantee = pg_roles.oid
+    WHERE rolname=$1
+) privs
+USING (relname, relnamespace, relkind)
+WHERE nspname = $2 AND relkind = $3
+GROUP BY pg_class.relname;
+`
+
+	objectType := d.Get("object_type").(string)
+	rows, err := txn.Query(
+		query, d.Get("role"), d.Get("schema"), objectTypes[objectType],
+	)
+	if err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var objName string
+		var privileges pq.ByteaArray
+
+		if err := rows.Scan(&objName, &privileges); err != nil {
+			return err
+		}
+		privilegesSet := pgArrayToSet(privileges)
+
+		if !privilegesSet.Equal(d.Get("privileges").(*schema.Set)) {
+			// If any object doesn't have the same privileges as saved in the state,
+			// we return an empty privileges to force an update.
+			log.Printf(
+				"[DEBUG] %s %s has not the expected privileges %v for role %s",
+				strings.ToTitle(objectType), objName, privileges, d.Get("role"),
+			)
+			d.Set("privileges", schema.NewSet(schema.HashString, []interface{}{}))
+			break
+		}
+
+	}
+
+	return nil
+}
+
+func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	privileges := []string{}
+	for _, priv := range d.Get("privileges").(*schema.Set).List() {
+		privileges = append(privileges, priv.(string))
+	}
+
+	query := fmt.Sprintf(
+		"GRANT %s ON ALL %sS IN SCHEMA %s TO %s",
+		strings.Join(privileges, ","),
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := fmt.Sprintf(
+		"REVOKE ALL PRIVILEGES ON ALL %sS IN SCHEMA %s FROM %s",
+		strings.ToUpper(d.Get("object_type").(string)),
+		pq.QuoteIdentifier(d.Get("schema").(string)),
+		pq.QuoteIdentifier(d.Get("role").(string)),
+	)
+
+	_, err := txn.Exec(query)
+	return err
+}
+
+func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, error) {
+	txn, err := startTransaction(client, "")
+	if err != nil {
+		return false, err
+	}
+	defer deferredRollback(txn)
+
+	// Check the role exists
+	role := d.Get("role").(string)
+	exists, err := roleExists(txn, role)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] role %s does not exists", role)
+		return false, nil
+	}
+
+	// Check the database exists
+	database := d.Get("database").(string)
+	exists, err = dbExists(txn, database)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] database %s does not exists", database)
+		return false, nil
+	}
+
+	// Connect on this database to check if schema exists
+	dbTxn, err := startTransaction(client, database)
+	if err != nil {
+		return false, err
+	}
+	defer dbTxn.Rollback()
+
+	// Check the schema exists (the SQL connection needs to be on the right database)
+	pgSchema := d.Get("schema").(string)
+	exists, err = schemaExists(txn, pgSchema)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		log.Printf("[DEBUG] schema %s does not exists", pgSchema)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func generateGrantID(d *schema.ResourceData) string {
+	return strings.Join([]string{
+		d.Get("role").(string), d.Get("database").(string),
+		d.Get("schema").(string), d.Get("object_type").(string),
+	}, "_")
+}

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -1,0 +1,70 @@
+package postgresql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPostgresqlGrant(t *testing.T) {
+	// We have to create the database outside of resource.Test
+	// because we need to create a table to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true, true)
+	defer teardown()
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+	var testGrantSelect = fmt.Sprintf(`
+	resource "postgresql_grant" "test_ro" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT"]
+	}
+	`, dbName, roleName)
+
+	var testGrantSelectInsertUpdate = fmt.Sprintf(`
+	resource "postgresql_grant" "test_ro" {
+		database    = "%s"
+		role        = "%s"
+		schema      = "public"
+		object_type = "table"
+		privileges   = ["SELECT", "INSERT", "UPDATE"]
+	}
+	`, dbName, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGrantSelect,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT"}, false)
+					},
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+				),
+			},
+			{
+				Config: testGrantSelectInsertUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT", "INSERT", "UPDATE"}, false)
+					},
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "3"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.892623219", "INSERT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.1759376126", "UPDATE"),
+				),
+			},
+		},
+	})
+}

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -10,10 +10,13 @@ import (
 
 func TestAccPostgresqlGrant(t *testing.T) {
 	// We have to create the database outside of resource.Test
-	// because we need to create a table to assert that grant are correctly applied
+	// because we need to create tables to assert that grant are correctly applied
 	// and we don't have this resource yet
-	dbSuffix, teardown := setupTestDatabase(t, true, true, true)
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
 	defer teardown()
+
+	testTables := []string{"test_table", "test_table2"}
+	createTestTables(t, dbSuffix, testTables)
 
 	dbName, roleName := getTestDBNames(dbSuffix)
 	var testGrantSelect = fmt.Sprintf(`
@@ -46,23 +49,23 @@ func TestAccPostgresqlGrant(t *testing.T) {
 			{
 				Config: testGrantSelect,
 				Check: resource.ComposeTestCheckFunc(
-					func(*terraform.State) error {
-						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT"}, false)
-					},
 					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "1"),
 					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+					func(*terraform.State) error {
+						return testCheckTablesPrivileges(t, dbSuffix, testTables, []string{"SELECT"})
+					},
 				),
 			},
 			{
 				Config: testGrantSelectInsertUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					func(*terraform.State) error {
-						return testCheckTablePrivileges(t, dbSuffix, []string{"SELECT", "INSERT", "UPDATE"}, false)
-					},
 					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "3"),
 					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
 					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.892623219", "INSERT"),
 					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.1759376126", "UPDATE"),
+					func(*terraform.State) error {
+						return testCheckTablesPrivileges(t, dbSuffix, testTables, []string{"SELECT", "INSERT", "UPDATE"})
+					},
 				),
 			},
 		},

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -266,7 +266,7 @@ func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	roleName := d.Get(roleNameAttr).(string)
 

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -162,7 +162,7 @@ func testAccCheckRoleCanLogin(t *testing.T, role, password string) resource.Test
 		config := getTestConfig(t)
 		config.Username = role
 		config.Password = password
-		db, err := sql.Open("postgres", config.connStr())
+		db, err := sql.Open("postgres", config.connStr("postgres"))
 		if err != nil {
 			return fmt.Errorf("could not open SQL connection: %v", err)
 		}

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -11,7 +11,10 @@ import (
 
 func TestAccPostgresqlRole_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlRoleDestroy,
 		Steps: []resource.TestStep{
@@ -62,7 +65,10 @@ resource "postgresql_role" "update_role" {
 }
 `
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlRoleDestroy,
 		Steps: []resource.TestStep{

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -162,7 +162,7 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	for _, query := range queries {
 		if _, err = txn.Exec(query); err != nil {
@@ -188,7 +188,7 @@ func resourcePostgreSQLSchemaDelete(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	schemaName := d.Get(schemaNameAttr).(string)
 
@@ -286,7 +286,7 @@ func resourcePostgreSQLSchemaUpdate(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	defer txn.Rollback()
+	defer deferredRollback(txn)
 
 	if err := setSchemaName(txn, d); err != nil {
 		return err

--- a/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/expand_json.go
@@ -1,0 +1,11 @@
+package structure
+
+import "encoding/json"
+
+func ExpandJsonFromString(jsonString string) (map[string]interface{}, error) {
+	var result map[string]interface{}
+
+	err := json.Unmarshal([]byte(jsonString), &result)
+
+	return result, err
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/flatten_json.go
@@ -1,0 +1,16 @@
+package structure
+
+import "encoding/json"
+
+func FlattenJsonToString(input map[string]interface{}) (string, error) {
+	if len(input) == 0 {
+		return "", nil
+	}
+
+	result, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/normalize_json.go
@@ -1,0 +1,24 @@
+package structure
+
+import "encoding/json"
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}

--- a/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
+++ b/vendor/github.com/hashicorp/terraform/helper/structure/suppress_json_diff.go
@@ -1,0 +1,21 @@
+package structure
+
+import (
+	"reflect"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func SuppressJsonDiff(k, old, new string, d *schema.ResourceData) bool {
+	oldMap, err := ExpandJsonFromString(old)
+	if err != nil {
+		return false
+	}
+
+	newMap, err := ExpandJsonFromString(new)
+	if err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldMap, newMap)
+}

--- a/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
+++ b/vendor/github.com/hashicorp/terraform/helper/validation/validation.go
@@ -1,0 +1,146 @@
+package validation
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/structure"
+)
+
+// IntBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is between min and max (inclusive)
+func IntBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min || v > max {
+			es = append(es, fmt.Errorf("expected %s to be in the range (%d - %d), got %d", k, min, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtLeast returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at least min (inclusive)
+func IntAtLeast(min int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v < min {
+			es = append(es, fmt.Errorf("expected %s to be at least (%d), got %d", k, min, v))
+			return
+		}
+
+		return
+	}
+}
+
+// IntAtMost returns a SchemaValidateFunc which tests if the provided value
+// is of type int and is at most max (inclusive)
+func IntAtMost(max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(int)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be int", k))
+			return
+		}
+
+		if v > max {
+			es = append(es, fmt.Errorf("expected %s to be at most (%d), got %d", k, max, v))
+			return
+		}
+
+		return
+	}
+}
+
+// StringInSlice returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice
+// will test with in lower case if ignoreCase is true
+func StringInSlice(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.ToLower(v) == strings.ToLower(str)) {
+				return
+			}
+		}
+
+		es = append(es, fmt.Errorf("expected %s to be one of %v, got %s", k, valid, v))
+		return
+	}
+}
+
+// StringLenBetween returns a SchemaValidateFunc which tests if the provided value
+// is of type string and has length between min and max (inclusive)
+func StringLenBetween(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+		if len(v) < min || len(v) > max {
+			es = append(es, fmt.Errorf("expected length of %s to be in the range (%d - %d), got %s", k, min, max, v))
+		}
+		return
+	}
+}
+
+// CIDRNetwork returns a SchemaValidateFunc which tests if the provided value
+// is of type string, is in valid CIDR network notation, and has significant bits between min and max (inclusive)
+func CIDRNetwork(min, max int) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		_, ipnet, err := net.ParseCIDR(v)
+		if err != nil {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid CIDR, got: %s with err: %s", k, v, err))
+			return
+		}
+
+		if ipnet == nil || v != ipnet.String() {
+			es = append(es, fmt.Errorf(
+				"expected %s to contain a valid network CIDR, expected %s, got %s",
+				k, ipnet, v))
+		}
+
+		sigbits, _ := ipnet.Mask.Size()
+		if sigbits < min || sigbits > max {
+			es = append(es, fmt.Errorf(
+				"expected %q to contain a network CIDR with between %d and %d significant bits, got: %d",
+				k, min, max, sigbits))
+		}
+
+		return
+	}
+}
+
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := structure.NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}

--- a/website/docs/r/postgresql_default_privileges.html.markdown
+++ b/website/docs/r/postgresql_default_privileges.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "postgresql"
+page_title: "PostgreSQL: postgresql_default_privileges"
+sidebar_current: "docs-postgresql-resource-postgresql_default_privileges"
+description: |-
+  Creates and manages default privileges given to a user for a database schema.
+---
+
+# postgresql\_default\_privileges
+
+The ``postgresql_default_privileges`` resource creates and manages default privileges given to a user for a database schema.
+
+~> **Note:** This resource needs Postgresql version 9 or above.
+
+## Usage
+
+```hcl
+resource postgresql_default_privileges "read_only_tables" {
+  role     = "test_role"
+  database = "test_db"
+  schema   = "public"
+
+  owner       = "db_owner"
+  object_type = "table"
+  privileges  = ["SELECT"]
+}
+```
+
+## Argument Reference
+
+* `role` - (Required) The name of the role to which grant default privileges on.
+* `database` - (Required) The database to grant default privileges for this role.
+* `owner` - (Required) Role for which apply default privileges (You can change default privileges only for objects that will be created by yourself or by roles that you are a member of).
+* `schema` - (Required) The database schema to set default privileges for this role.
+* `object_type` - (Required) The PostgreSQL object type to set the default privileges on (one of: table, sequence).
+* `privileges` - (Required) The list of privileges to apply as default privileges.

--- a/website/docs/r/postgresql_grant.html.markdown
+++ b/website/docs/r/postgresql_grant.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "postgresql"
+page_title: "PostgreSQL: postgresql_grant"
+sidebar_current: "docs-postgresql-resource-postgresql_grant"
+description: |-
+  Creates and manages privileges given to a user for a database schema.
+---
+
+# postgresql\_grant
+
+The ``postgresql_grant`` resource creates and manages privileges given to a user for a database schema.
+
+~> **Note:** This resource needs Postgresql version 9 or above.
+
+## Usage
+
+```hcl
+resource postgresql_grant "readonly_tables" {
+  database    = "test_db"
+  role        = "test_role"
+  schema      = "public"
+  object_type = "table"
+  privileges  = ["SELECT"]
+}
+```
+
+## Argument Reference
+
+* `role` - (Required) The name of the role to grant privileges on.
+* `database` - (Required) The database to grant privileges on for this role.
+* `schema` - (Required) The database schema to grant privileges on for this role.
+* `object_type` - (Required) The PostgreSQL object type to grant the privileges on (one of: table, sequence).
+* `privileges` - (Required) The list of privileges to grant.

--- a/website/postgresql.erb
+++ b/website/postgresql.erb
@@ -19,6 +19,9 @@
                     <li<%= sidebar_current("docs-postgresql-resource-postgresql_extension") %>>
                         <a href="/docs/providers/postgresql/r/postgresql_extension.html">postgresql_extension</a>
                     </li>
+                    <li<%= sidebar_current("docs-postgresql-resource-postgresql_grant") %>>
+                        <a href="/docs/providers/postgresql/r/postgresql_grant.html">postgresql_grant</a>
+                    </li>
                     <li<%= sidebar_current("docs-postgresql-resource-postgresql_role") %>>
                         <a href="/docs/providers/postgresql/r/postgresql_role.html">postgresql_role</a>
                     </li>

--- a/website/postgresql.erb
+++ b/website/postgresql.erb
@@ -16,6 +16,9 @@
                     <li<%= sidebar_current("docs-postgresql-resource-postgresql_database") %>>
                         <a href="/docs/providers/postgresql/r/postgresql_database.html">postgresql_database</a>
                     </li>
+                    <li<%= sidebar_current("docs-postgresql-resource-postgresql_default_privileges") %>>
+                        <a href="/docs/providers/postgresql/r/postgresql_default_privileges.html">postgresql_default_privileges</a>
+                    </li>
                     <li<%= sidebar_current("docs-postgresql-resource-postgresql_extension") %>>
                         <a href="/docs/providers/postgresql/r/postgresql_extension.html">postgresql_extension</a>
                     </li>


### PR DESCRIPTION
Add resources:
* postgresql_grant: Allow to manage [grant](https://www.postgresql.org/docs/current/sql-grant.html)  for tables or sequences for a specified role in a schema.
* postgresql_default_privileges: Allow to manage [default privileges](https://www.postgresql.org/docs/current/sql-alterdefaultprivileges.html) for tables or sequences for a specified role in a schema.