### PR TITLE
Fix role password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ BUG FIXES:
 
 * Parse Azure PostgreSQL version
   ([#40](https://github.com/terraform-providers/terraform-provider-postgresql/pull/40))
+* Fix: Updating a role password doesn't actually update the role password
+  [https://github.com/terraform-providers/terraform-provider-postgresql/issues/16]
 
 ## 0.1.2 (July 06, 2018)
 

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -389,34 +389,38 @@ func resourcePostgreSQLRoleReadImpl(d *schema.ResourceData, meta interface{}) er
 
 	d.SetId(roleName)
 
-	var rolePassword string
-	err = c.DB().QueryRow("SELECT COALESCE(passwd, '') FROM pg_catalog.pg_shadow AS s WHERE s.usename = $1", roleId).Scan(&rolePassword)
-	switch {
-	case err == sql.ErrNoRows:
-		// They don't have a password
-		d.Set(rolePasswordAttr, "")
-		return nil
-	case err != nil:
-		return errwrap.Wrapf("Error reading role: {{err}}", err)
-	}
-
-	// If the password isn't already in md5 format, but hashing the input
-	// matches the password in the database for the user, they are the same
-	password := d.Get("password").(string)
-	if !strings.HasPrefix(password, "md5") {
-		hasher := md5.New()
-		hasher.Write([]byte(password + roleId))
-		hashedPassword := "md5" + hex.EncodeToString(hasher.Sum(nil))
-
-		if hashedPassword == rolePassword {
-			// The passwords are actually the same
-			// make Terraform think they are the same
-			d.Set(rolePasswordAttr, password)
+	password := d.Get(rolePasswordAttr).(string)
+	// Role which cannot login does not have password in pg_shadow.
+	if roleCanLogin {
+		var rolePassword string
+		err = c.DB().QueryRow("SELECT COALESCE(passwd, '') FROM pg_catalog.pg_shadow AS s WHERE s.usename = $1", roleId).Scan(&rolePassword)
+		switch {
+		case err == sql.ErrNoRows:
+			// They don't have a password
+			d.Set(rolePasswordAttr, "")
 			return nil
+		case err != nil:
+			return errwrap.Wrapf("Error reading role: {{err}}", err)
 		}
-	}
 
-	d.Set(rolePasswordAttr, rolePassword)
+		// If the password isn't already in md5 format, but hashing the input
+		// matches the password in the database for the user, they are the same
+		if password != "" && !strings.HasPrefix(password, "md5") {
+			hasher := md5.New()
+			hasher.Write([]byte(password + roleId))
+			hashedPassword := "md5" + hex.EncodeToString(hasher.Sum(nil))
+
+			if hashedPassword == rolePassword {
+				// The passwords are actually the same
+				// make Terraform think they are the same
+				d.Set(rolePasswordAttr, password)
+				return nil
+			}
+		}
+		d.Set(rolePasswordAttr, rolePassword)
+		return nil
+	}
+	d.Set(rolePasswordAttr, password)
 	return nil
 }
 
@@ -428,6 +432,10 @@ func resourcePostgreSQLRoleUpdate(d *schema.ResourceData, meta interface{}) erro
 	db := c.DB()
 
 	if err := setRoleName(db, d); err != nil {
+		return err
+	}
+
+	if err := setRolePassword(db, d); err != nil {
 		return err
 	}
 
@@ -489,6 +497,23 @@ func setRoleName(db *sql.DB, d *schema.ResourceData) error {
 
 	d.SetId(n)
 
+	return nil
+}
+
+func setRolePassword(db *sql.DB, d *schema.ResourceData) error {
+	// If role is renamed, password is reset (as the md5 sum is also base on the role name)
+	// so we need to update it
+	if !d.HasChange(rolePasswordAttr) && !d.HasChange(roleNameAttr) {
+		return nil
+	}
+
+	roleName := d.Get(roleNameAttr).(string)
+	password := d.Get(rolePasswordAttr).(string)
+
+	sql := fmt.Sprintf("ALTER ROLE %s PASSWORD '%s'", pq.QuoteIdentifier(roleName), pqQuoteLiteral(password))
+	if _, err := db.Exec(sql); err != nil {
+		return errwrap.Wrapf("Error updating role password: {{err}}", err)
+	}
 	return nil
 }
 

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -32,9 +32,6 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "valid_until", "infinity"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_drop_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_reassign_owned", "false"),
-
-					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "name", "role_with_superuser"),
-					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "superuser", "true"),
 				),
 			},
 		},
@@ -173,13 +170,6 @@ resource "postgresql_role" "role_with_defaults" {
   skip_drop_role = false
   skip_reassign_owned = false
   valid_until = "infinity"
-}
-
-resource "postgresql_role" "role_with_superuser" {
-  name = "role_with_superuser"
-  superuser = true
-  login = true
-  password = "mypass"
 }
 `
 

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -28,10 +28,13 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "bypass_row_level_security", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "encrypted_password", "true"),
-					resource.TestCheckNoResourceAttr("postgresql_role.role_with_defaults", "password"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "password", ""),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "valid_until", "infinity"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_drop_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_reassign_owned", "false"),
+
+					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "name", "role_with_superuser"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "superuser", "true"),
 				),
 			},
 		},
@@ -151,11 +154,6 @@ resource "postgresql_role" "role_with_pwd_encr" {
   encrypted = true
 }
 
-resource "postgresql_role" "role_with_pwd_no_login" {
-  name = "role_with_pwd_no_login"
-  password = "mypass"
-}
-
 resource "postgresql_role" "role_simple" {
   name = "role_simple"
 }
@@ -175,6 +173,13 @@ resource "postgresql_role" "role_with_defaults" {
   skip_drop_role = false
   skip_reassign_owned = false
   valid_until = "infinity"
+}
+
+resource "postgresql_role" "role_with_superuser" {
+  name = "role_with_superuser"
+  superuser = true
+  login = true
+  password = "mypass"
 }
 `
 

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -82,11 +82,8 @@ resource "postgresql_role" "my_replication_role" {
   behavior of
   [PostgreSQL's `password_encryption` setting](https://www.postgresql.org/docs/current/static/runtime-config-connection.html#GUC-PASSWORD-ENCRYPTION).
 
-* `password` - (Optional) Sets the role's password. (A password is only of use
-  for roles having the `login` attribute set to true, but you can nonetheless
-  define one for roles without it.) Roles without a password explicitly set are
-  left alone.  If the password is set to the magic value `NULL`, the password
-  will be always be cleared.
+* `password` - (Optional) Sets the role's password. A password is only of use
+  for roles having the `login` attribute set to true.
 
 * `valid_until` - (Optional) Defines the date and time after which the role's
   password is no longer valid.  Established connections past this `valid_time`


### PR DESCRIPTION
This PR depends on the work of @nguse in #44 which is fixing diff for encrypted password.

Our enhancements:

* Really updating password in the `resourcePostgreSQLRoleUpdate` function.
* Don't compare password if the role has not `login` access. Otherwise there's no entry in `pg_shadow`  for it  and plan will always want to update it. (This fixes the tests)
* Force to set the password if the role is renamed. As the [documentation](https://www.postgresql.org/docs/current/sql-alterrole.html) says:

> Because MD5-encrypted passwords use the role name as cryptographic salt, renaming a role clears its password if the password is MD5-encrypted.


Fix #16 