### PR TITLE
config: Add a database_username parameter for users map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ TESTS:
 
 * Travis: Run acceptance tests against multiple Postgres versions.
 
+FEATURES:
+
+* Add `database_username` in provider configuration to manage [user name maps](https://www.postgresql.org/docs/current/auth-username-maps.html)
+  ([#58](https://github.com/terraform-providers/terraform-provider-postgresql/pull/58))
+
 ## 0.1.3 (December 19, 2018)
 
 BUG FIXES:

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	Database          string
 	Username          string
 	Password          string
+	DatabaseUsername  string
 	SSLMode           string
 	ApplicationName   string
 	Timeout           int
@@ -243,6 +244,13 @@ func (c *Config) connStr() string {
 	}
 
 	return connStr
+}
+
+func (c *Config) getDatabaseUsername() string {
+	if c.DatabaseUsername != "" {
+		return c.DatabaseUsername
+	}
+	return c.Username
 }
 
 // DB returns a copy to an sql.Open()'ed database connection.  Callers must

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -49,6 +49,14 @@ func Provider() terraform.ResourceProvider {
 				Description: "Password to be used if the PostgreSQL server demands password authentication",
 				Sensitive:   true,
 			},
+			// Conection username can be different than database username with user name mapas (e.g.: in Azure)
+			// See https://www.postgresql.org/docs/current/auth-username-maps.html
+			"database_username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Database username associated to the connected user (for user name maps)",
+			},
+
 			"sslmode": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -136,6 +144,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Database:          d.Get("database").(string),
 		Username:          d.Get("username").(string),
 		Password:          d.Get("password").(string),
+		DatabaseUsername:  d.Get("database_username").(string),
 		SSLMode:           sslMode,
 		ApplicationName:   tfAppName(),
 		ConnectTimeoutSec: d.Get("connect_timeout").(int),

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -275,7 +275,7 @@ func resourcePostgreSQLRoleDelete(d *schema.ResourceData, meta interface{}) erro
 		if c.featureSupported(featureReassignOwnedCurrentUser) {
 			queries = append(queries, fmt.Sprintf("REASSIGN OWNED BY %s TO CURRENT_USER", pq.QuoteIdentifier(roleName)))
 		} else {
-			queries = append(queries, fmt.Sprintf("REASSIGN OWNED BY %s TO %s", pq.QuoteIdentifier(roleName), pq.QuoteIdentifier(c.config.Username)))
+			queries = append(queries, fmt.Sprintf("REASSIGN OWNED BY %s TO %s", pq.QuoteIdentifier(roleName), pq.QuoteIdentifier(c.config.getDatabaseUsername())))
 		}
 		queries = append(queries, fmt.Sprintf("DROP OWNED BY %s", pq.QuoteIdentifier(roleName)))
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
 * `database` - (Optional) Database to connect to. The default is `postgres`.
 * `username` - (Required) Username for the server connection.
 * `password` - (Optional) Password for the server connection.
+* `database_username` - (Optional) Username of the user in the database if different than connection username (See [user name maps](https://www.postgresql.org/docs/current/auth-username-maps.html)).
 * `sslmode` - (Optional) Set the priority for an SSL connection to the server.
   Valid values for `sslmode` are (note: `prefer` is not supported by Go's
   [`lib/pq`](https://godoc.org/github.com/lib/pq)):


### PR DESCRIPTION
With [user name maps](https://www.postgresql.org/docs/current/auth-username-maps.html), connection username can be different than associated role name in database.

Fix #55 