### PR TITLE
Fix the way the owner is granted / revoked when managing a database.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ BUG FIXES:
   ([#61](https://github.com/terraform-providers/terraform-provider-postgresql/pull/61))
 * Disable REPLICATION flag in role for Postgres < 9.1.
   ([#61](https://github.com/terraform-providers/terraform-provider-postgresql/pull/61))
+* `postgresql_database`: Fix the way the database owner is granted / revoked during create/update/delete.
+  ([#59](https://github.com/terraform-providers/terraform-provider-postgresql/pull/59))
 
 TESTS:
 

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -3,6 +3,11 @@ package postgresql
 import (
 	"fmt"
 	"strings"
+
+	"database/sql"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/lib/pq"
 )
 
 // pqQuoteLiteral returns a string literal safe for inclusion in a PostgreSQL
@@ -21,4 +26,68 @@ func validateConnLimit(v interface{}, key string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("%s can not be less than -1", key))
 	}
 	return
+}
+
+func isRoleMember(db *sql.DB, role, member string) (bool, error) {
+	var _rez int
+	err := db.QueryRow(
+		"SELECT 1 FROM pg_auth_members WHERE pg_get_userbyid(roleid) = $1 AND pg_get_userbyid(member) = $2",
+		role, member,
+	).Scan(&_rez)
+
+	switch {
+	case err == sql.ErrNoRows:
+		return false, nil
+	case err != nil:
+		return false, errwrap.Wrapf("could not real role membership: {{err}}", err)
+	}
+
+	return true, nil
+}
+
+// grantRoleMembership grants the role *role* to the user *member*.
+// It returns false if the grant is not needed because the user is already
+// a member of this role.
+func grantRoleMembership(db *sql.DB, role, member string) (bool, error) {
+	if member == role {
+		return false, nil
+	}
+
+	isMember, err := isRoleMember(db, role, member)
+	if err != nil {
+		return false, err
+	}
+
+	if isMember {
+		return false, nil
+	}
+
+	sql := fmt.Sprintf("GRANT %s TO %s", pq.QuoteIdentifier(role), pq.QuoteIdentifier(member))
+	if _, err := db.Exec(sql); err != nil {
+		return false, errwrap.Wrapf(fmt.Sprintf(
+			"Error granting role %s to %s: {{err}}", role, member,
+		), err)
+	}
+	return true, nil
+}
+
+func revokeRoleMembership(db *sql.DB, role, member string) error {
+	if member == role {
+		return nil
+	}
+
+	isMember, err := isRoleMember(db, role, member)
+	if err != nil {
+		return err
+	}
+
+	if isMember {
+		sql := fmt.Sprintf("REVOKE %s FROM %s", pq.QuoteIdentifier(role), pq.QuoteIdentifier(member))
+		if _, err := db.Exec(sql); err != nil {
+			return errwrap.Wrapf(fmt.Sprintf(
+				"Error revoking role %s from %s: {{err}}", role, member,
+			), err)
+		}
+	}
+	return nil
 }

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -1,0 +1,65 @@
+package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+const (
+	dbNamePrefix     = "tf_tests_db"
+	roleNamePrefix   = "tf_tests_role"
+	testRolePassword = "testpwd"
+
+	testTableDef = "CREATE TABLE test_table (val text)"
+)
+
+func getTestConfig(t *testing.T) Config {
+	getEnv := func(key, fallback string) string {
+		value := os.Getenv(key)
+		if len(value) == 0 {
+			return fallback
+		}
+		return value
+	}
+
+	dbPort, err := strconv.Atoi(getEnv("PGPORT", "5432"))
+	if err != nil {
+		t.Fatalf("could not cast PGPORT value as integer: %v", err)
+	}
+
+	return Config{
+		Host:     getEnv("PGHOST", "localhost"),
+		Port:     dbPort,
+		Username: getEnv("PGUSER", ""),
+		Password: getEnv("PGPASSWORD", ""),
+		Database: getEnv("PGDATABASE", "postgres"),
+		SSLMode:  getEnv("PGSSLMODE", ""),
+	}
+}
+
+func skipIfNotAcc(t *testing.T) {
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf(
+			"Acceptance tests skipped unless env '%s' set",
+			resource.TestEnvVar))
+	}
+}
+
+// dbExecute is a test helper to create a pool, execute one query then close the pool
+func dbExecute(t *testing.T, dsn, query string, args ...interface{}) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("could to create connection pool: %v", err)
+	}
+	defer db.Close()
+
+	// Create the test DB
+	if _, err = db.Exec(query, args...); err != nil {
+		t.Fatalf("could not execute query %s: %v", query, err)
+	}
+}


### PR DESCRIPTION
The owner was revoked from connected user even in the case where the grant was not needed because the it was already a member of the owner role.

Depends on #58 

(I move the grant/revoke methods in `helpers.go` because we'll need to do the same things in `postgresql_role` for the `REASSIGN OWNER` , see #36 )