### PR TITLE
Travis: Build agains multiple Postgres version + fix bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ language: go
 go:
   - "1.11.x"
 
+env:
+  - PGVERSION=latest
+  - PGVERSION=10
+  - PGVERSION=9
+  - PGVERSION=8.4
+
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch
@@ -19,6 +25,10 @@ script:
 - make vendor-status
 - make vet
 - make website-test
+- source tests/env.sh
+- docker-compose -f tests/docker-compose.yml up -d
+- tests/wait-postgres-docker.sh tests/docker-compose.yml
+- make testacc
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,21 @@ BUG FIXES:
   ([#43](https://github.com/terraform-providers/terraform-provider-postgresql/pull/43))
 * Updating a role password doesn't actually update the role password
   [https://github.com/terraform-providers/terraform-provider-postgresql/issues/16]
-  ([#54](https://github.com/terraform-providers/terraform-provider-postgresql/pull/43))
+  ([#54](https://github.com/terraform-providers/terraform-provider-postgresql/pull/54))
 * `superuser` is now being applied correctly on role creation
-  ([#45](https://github.com/terraform-providers/terraform-provider-postgresql/pull/43))
+  ([#45](https://github.com/terraform-providers/terraform-provider-postgresql/pull/45))
+* Feature flag system was not working.
+  ([#61](https://github.com/terraform-providers/terraform-provider-postgresql/pull/61))
+* Updating database does not work for connection_limit / allow_connection / is_template
+  ([#61](https://github.com/terraform-providers/terraform-provider-postgresql/pull/61))
+* Disable postgresql_extension for Postgres < 9.1
+  ([#61](https://github.com/terraform-providers/terraform-provider-postgresql/pull/61))
+* Disable REPLICATION flag in role for Postgres < 9.1.
+  ([#61](https://github.com/terraform-providers/terraform-provider-postgresql/pull/61))
+
+TESTS:
+
+* Travis: Run acceptance tests against multiple Postgres versions.
 
 ## 0.1.3 (December 19, 2018)
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -24,6 +24,7 @@ const (
 	featureRLS
 	featureReassignOwnedCurrentUser
 	featureSchemaCreateIfNotExist
+	featureReplication
 )
 
 type dbRegistryEntry struct {

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -58,6 +58,9 @@ var (
 
 		// row-level security
 		featureRLS: semver.MustParseRange(">=9.5.0"),
+
+		// CREATE ROLE has REPLICATION support.
+		featureReplication: semver.MustParseRange(">=9.1.0"),
 	}
 )
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -25,6 +25,7 @@ const (
 	featureReassignOwnedCurrentUser
 	featureSchemaCreateIfNotExist
 	featureReplication
+	featureExtension
 )
 
 type dbRegistryEntry struct {
@@ -61,6 +62,9 @@ var (
 
 		// CREATE ROLE has REPLICATION support.
 		featureReplication: semver.MustParseRange(">=9.1.0"),
+
+		// CREATE EXTENSION support.
+		featureExtension: semver.MustParseRange(">=9.1.0"),
 	}
 )
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -128,8 +128,9 @@ func (c *Config) NewClient() (*Client, error) {
 	}
 
 	client := Client{
-		config: *c,
-		db:     dbEntry.db,
+		config:  *c,
+		db:      dbEntry.db,
+		version: dbEntry.version,
 	}
 
 	return &client, nil

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -483,8 +483,8 @@ func setDBConnLimit(db *sql.DB, d *schema.ResourceData) error {
 
 	connLimit := d.Get(dbConnLimitAttr).(int)
 	dbName := d.Get(dbNameAttr).(string)
-	sql := fmt.Sprintf("ALTER DATABASE %s CONNECTION LIMIT = $1", pq.QuoteIdentifier(dbName))
-	if _, err := db.Exec(sql, connLimit); err != nil {
+	sql := fmt.Sprintf("ALTER DATABASE %s CONNECTION LIMIT = %d", pq.QuoteIdentifier(dbName), connLimit)
+	if _, err := db.Exec(sql); err != nil {
 		return errwrap.Wrapf("Error updating database CONNECTION LIMIT: {{err}}", err)
 	}
 
@@ -502,8 +502,8 @@ func setDBAllowConns(c *Client, d *schema.ResourceData) error {
 
 	allowConns := d.Get(dbAllowConnsAttr).(bool)
 	dbName := d.Get(dbNameAttr).(string)
-	sql := fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS $1", pq.QuoteIdentifier(dbName))
-	if _, err := c.DB().Exec(sql, allowConns); err != nil {
+	sql := fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS %t", pq.QuoteIdentifier(dbName), allowConns)
+	if _, err := c.DB().Exec(sql); err != nil {
 		return errwrap.Wrapf("Error updating database ALLOW_CONNECTIONS: {{err}}", err)
 	}
 
@@ -527,8 +527,8 @@ func doSetDBIsTemplate(c *Client, dbName string, isTemplate bool) error {
 		return fmt.Errorf("PostgreSQL client is talking with a server (%q) that does not support database IS_TEMPLATE", c.version.String())
 	}
 
-	sql := fmt.Sprintf("ALTER DATABASE %s IS_TEMPLATE $1", pq.QuoteIdentifier(dbName))
-	if _, err := c.DB().Exec(sql, isTemplate); err != nil {
+	sql := fmt.Sprintf("ALTER DATABASE %s IS_TEMPLATE %t", pq.QuoteIdentifier(dbName), isTemplate)
+	if _, err := c.DB().Exec(sql); err != nil {
 		return errwrap.Wrapf("Error updating database IS_TEMPLATE: {{err}}", err)
 	}
 

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -133,6 +133,45 @@ func TestAccPostgresqlDatabase_DefaultOwner(t *testing.T) {
 	})
 }
 
+func TestAccPostgresqlDatabase_Update(t *testing.T) {
+
+	var createConfig = `
+resource postgresql_database test_db {
+    name = "test_db"
+}
+`
+	var updateConfig = `
+resource postgresql_database test_db {
+	name = "test_db"
+	connection_limit = 2
+	allow_connections = false
+}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
+					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "-1"),
+				),
+			},
+			{
+				Config: updateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
+					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPostgresqlDatabaseDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*Client)
 

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -41,8 +42,6 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"postgresql_database.default_opts", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr(
-						"postgresql_database.default_opts", "allow_connections", "true"),
-					resource.TestCheckResourceAttr(
 						"postgresql_database.default_opts", "is_template", "false"),
 
 					resource.TestCheckResourceAttr(
@@ -61,8 +60,6 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 						"postgresql_database.modified_opts", "tablespace_name", "pg_default"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.modified_opts", "connection_limit", "10"),
-					resource.TestCheckResourceAttr(
-						"postgresql_database.modified_opts", "allow_connections", "false"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.modified_opts", "is_template", "true"),
 
@@ -83,8 +80,6 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pathological_opts", "connection_limit", "0"),
 					resource.TestCheckResourceAttr(
-						"postgresql_database.pathological_opts", "allow_connections", "true"),
-					resource.TestCheckResourceAttr(
 						"postgresql_database.pathological_opts", "is_template", "true"),
 
 					resource.TestCheckResourceAttr(
@@ -103,8 +98,6 @@ func TestAccPostgresqlDatabase_Basic(t *testing.T) {
 					// 	"postgresql_database.pg_default_opts", "tablespace_name", "DEFAULT"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pg_default_opts", "connection_limit", "0"),
-					resource.TestCheckResourceAttr(
-						"postgresql_database.pg_default_opts", "allow_connections", "true"),
 					resource.TestCheckResourceAttr(
 						"postgresql_database.pg_default_opts", "is_template", "true"),
 				),
@@ -135,37 +128,55 @@ func TestAccPostgresqlDatabase_DefaultOwner(t *testing.T) {
 
 func TestAccPostgresqlDatabase_Update(t *testing.T) {
 
-	var createConfig = `
+	// Version dependent features values will be set in PreCheck
+	// because we need to access database to check Postgres version.
+
+	// Allow connection depends of Postgres version (needs pg >= 9.5)
+	var allowConnections bool
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+
+			client := testAccProvider.Meta().(*Client)
+			allowConnections = client.featureSupported(featureDBAllowConnections)
+
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlDatabaseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
 resource postgresql_database test_db {
     name = "test_db"
+	allow_connections = "%t"
 }
-`
-	var updateConfig = `
+`, allowConnections),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
+					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
+					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "-1"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.test_db", "allow_connections",
+						strconv.FormatBool(allowConnections),
+					),
+				),
+			},
+			{
+				Config: `
 resource postgresql_database test_db {
 	name = "test_db"
 	connection_limit = 2
 	allow_connections = false
 }
-	`
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPostgresqlDatabaseDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: createConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
-					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
-					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "-1"),
-				),
-			},
-			{
-				Config: updateConfig,
+	`,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPostgresqlDatabaseExists("postgresql_database.test_db"),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "name", "test_db"),
 					resource.TestCheckResourceAttr("postgresql_database.test_db", "connection_limit", "2"),
+					resource.TestCheckResourceAttr(
+						"postgresql_database.test_db", "allow_connections", "false",
+					),
 				),
 			},
 		},
@@ -258,7 +269,6 @@ resource "postgresql_database" "default_opts" {
    lc_ctype = "C"
    tablespace_name = "pg_default"
    connection_limit = -1
-   allow_connections = true
    is_template = false
 }
 
@@ -271,7 +281,6 @@ resource "postgresql_database" "modified_opts" {
    lc_ctype = "en_US.UTF-8"
    tablespace_name = "pg_default"
    connection_limit = 10
-   allow_connections = false
    is_template = true
 }
 
@@ -284,7 +293,6 @@ resource "postgresql_database" "pathological_opts" {
    lc_ctype = "C"
    tablespace_name = "pg_default"
    connection_limit = 0
-   allow_connections = true
    is_template = true
 }
 
@@ -307,7 +315,6 @@ resource "postgresql_database" "pg_default_opts" {
   lc_ctype = "DEFAULT"
   tablespace_name = "DEFAULT"
   connection_limit = 0
-  allow_connections = true
   is_template = true
 }
 

--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -53,6 +53,14 @@ func resourcePostgreSQLExtension() *schema.Resource {
 
 func resourcePostgreSQLExtensionCreate(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
+
+	if !c.featureSupported(featureExtension) {
+		return fmt.Errorf(
+			"postgresql_extension resource is not supported for this Postgres version (%s)",
+			c.version,
+		)
+	}
+
 	c.catalogLock.Lock()
 	defer c.catalogLock.Unlock()
 
@@ -81,6 +89,14 @@ func resourcePostgreSQLExtensionCreate(d *schema.ResourceData, meta interface{})
 
 func resourcePostgreSQLExtensionExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	c := meta.(*Client)
+
+	if !c.featureSupported(featureExtension) {
+		return false, fmt.Errorf(
+			"postgresql_extension resource is not supported for this Postgres version (%s)",
+			c.version,
+		)
+	}
+
 	c.catalogLock.Lock()
 	defer c.catalogLock.Unlock()
 
@@ -99,6 +115,14 @@ func resourcePostgreSQLExtensionExists(d *schema.ResourceData, meta interface{})
 
 func resourcePostgreSQLExtensionRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
+
+	if !c.featureSupported(featureExtension) {
+		return fmt.Errorf(
+			"postgresql_extension resource is not supported for this Postgres version (%s)",
+			c.version,
+		)
+	}
+
 	c.catalogLock.RLock()
 	defer c.catalogLock.RUnlock()
 
@@ -133,6 +157,14 @@ func resourcePostgreSQLExtensionReadImpl(d *schema.ResourceData, meta interface{
 
 func resourcePostgreSQLExtensionDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
+
+	if !c.featureSupported(featureExtension) {
+		return fmt.Errorf(
+			"postgresql_extension resource is not supported for this Postgres version (%s)",
+			c.version,
+		)
+	}
+
 	c.catalogLock.Lock()
 	defer c.catalogLock.Unlock()
 
@@ -150,6 +182,14 @@ func resourcePostgreSQLExtensionDelete(d *schema.ResourceData, meta interface{})
 
 func resourcePostgreSQLExtensionUpdate(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
+
+	if !c.featureSupported(featureExtension) {
+		return fmt.Errorf(
+			"postgresql_extension resource is not supported for this Postgres version (%s)",
+			c.version,
+		)
+	}
+
 	c.catalogLock.Lock()
 	defer c.catalogLock.Unlock()
 

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -9,9 +9,19 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func testCheckCompatibleVersion(t *testing.T) {
+	client := testAccProvider.Meta().(*Client)
+	if !client.featureSupported(featureExtension) {
+		t.Skip(fmt.Sprintf("Skip extension tests for Postgres %s", client.version))
+	}
+}
+
 func TestAccPostgresqlExtension_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
 		Steps: []resource.TestStep{
@@ -84,7 +94,10 @@ func testAccCheckPostgresqlExtensionExists(n string) resource.TestCheckFunc {
 
 func TestAccPostgresqlExtension_SchemaRename(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
 		Steps: []resource.TestStep{

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -330,7 +330,7 @@ func resourcePostgreSQLRoleReadImpl(d *schema.ResourceData, meta interface{}) er
 	c := meta.(*Client)
 
 	roleId := d.Id()
-	var roleSuperuser, roleInherit, roleCreateRole, roleCreateDB, roleCanLogin, roleReplication bool
+	var roleSuperuser, roleInherit, roleCreateRole, roleCreateDB, roleCanLogin, roleReplication, roleBypassRLS bool
 	var roleConnLimit int
 	var roleName, roleValidUntil string
 
@@ -341,23 +341,33 @@ func resourcePostgreSQLRoleReadImpl(d *schema.ResourceData, meta interface{}) er
 		"rolcreaterole",
 		"rolcreatedb",
 		"rolcanlogin",
-		"rolreplication",
 		"rolconnlimit",
 		`COALESCE(rolvaliduntil::TEXT, 'infinity')`,
 	}
 
-	roleSQL := fmt.Sprintf("SELECT %s FROM pg_catalog.pg_roles WHERE rolname=$1", strings.Join(columns, ", "))
-	err := c.DB().QueryRow(roleSQL, roleId).Scan(
+	values := []interface{}{
 		&roleName,
 		&roleSuperuser,
 		&roleInherit,
 		&roleCreateRole,
 		&roleCreateDB,
 		&roleCanLogin,
-		&roleReplication,
 		&roleConnLimit,
 		&roleValidUntil,
-	)
+	}
+
+	if c.featureSupported(featureReplication) {
+		columns = append(columns, "rolreplication")
+		values = append(values, &roleReplication)
+	}
+
+	if c.featureSupported(featureRLS) {
+		columns = append(columns, "rolbypassrls")
+		values = append(values, &roleBypassRLS)
+	}
+
+	roleSQL := fmt.Sprintf("SELECT %s FROM pg_catalog.pg_roles WHERE rolname=$1", strings.Join(columns, ", "))
+	err := c.DB().QueryRow(roleSQL, roleId).Scan(values...)
 	switch {
 	case err == sql.ErrNoRows:
 		log.Printf("[WARN] PostgreSQL ROLE (%s) not found", roleId)
@@ -374,21 +384,13 @@ func resourcePostgreSQLRoleReadImpl(d *schema.ResourceData, meta interface{}) er
 	d.Set(roleEncryptedPassAttr, true)
 	d.Set(roleInheritAttr, roleInherit)
 	d.Set(roleLoginAttr, roleCanLogin)
-	d.Set(roleReplicationAttr, roleReplication)
 	d.Set(roleSkipDropRoleAttr, d.Get(roleSkipDropRoleAttr).(bool))
 	d.Set(roleSkipReassignOwnedAttr, d.Get(roleSkipReassignOwnedAttr).(bool))
 	d.Set(roleSuperuserAttr, roleSuperuser)
 	d.Set(roleValidUntilAttr, roleValidUntil)
 
-	if c.featureSupported(featureRLS) {
-		var roleBypassRLS bool
-		roleSQL := "SELECT rolbypassrls FROM pg_catalog.pg_roles WHERE rolname=$1"
-		err = c.DB().QueryRow(roleSQL, roleId).Scan(&roleBypassRLS)
-		if err != nil {
-			return errwrap.Wrapf("Error reading RLS properties for ROLE: {{err}}", err)
-		}
-		d.Set(roleBypassRLSAttr, roleBypassRLS)
-	}
+	d.Set(roleReplicationAttr, roleReplication)
+	d.Set(roleReplicationAttr, roleBypassRLS)
 
 	d.SetId(roleName)
 

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -170,14 +170,16 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 		{roleCreateRoleAttr, "CREATEROLE", "NOCREATEROLE"},
 		{roleInheritAttr, "INHERIT", "NOINHERIT"},
 		{roleLoginAttr, "LOGIN", "NOLOGIN"},
-		{roleReplicationAttr, "REPLICATION", "NOREPLICATION"},
-
 		// roleEncryptedPassAttr is used only when rolePasswordAttr is set.
 		// {roleEncryptedPassAttr, "ENCRYPTED", "UNENCRYPTED"},
 	}
 
 	if c.featureSupported(featureRLS) {
 		boolOpts = append(boolOpts, boolOptType{roleBypassRLSAttr, "BYPASSRLS", "NOBYPASSRLS"})
+	}
+
+	if c.featureSupported(featureReplication) {
+		boolOpts = append(boolOpts, boolOptType{roleReplicationAttr, "REPLICATION", "NOREPLICATION"})
 	}
 
 	createOpts := make([]string, 0, len(stringOpts)+len(intOpts)+len(boolOpts))

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+    postgres:
+        image: postgres:${PGVERSION:-latest}
+        environment:
+            POSTGRESQL_PASSWORD: ${PGPASSWORD}
+        ports:
+            - 25432:5432

--- a/tests/env.sh
+++ b/tests/env.sh
@@ -1,0 +1,6 @@
+export TF_ACC=true
+export PGHOST=localhost
+export PGPORT=25432
+export PGUSER=postgres
+export PGPASSWORD=testpwd
+export PGSSLMODE=disable

--- a/tests/wait-postgres-docker.sh
+++ b/tests/wait-postgres-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+COMPOSE_FILE=${1:-"docker-compose.yml"}
+
+TIMEOUT=30
+
+if [ ! -e "$COMPOSE_FILE" ]; then
+    echo "Unable to find docker-compose file: $COMPOSE_FILE"
+    exit 1
+fi
+
+echo "Waiting for database to be up"
+i=0
+until docker-compose -f "$COMPOSE_FILE" logs postgres | grep "ready to accept connections" > /dev/null; do
+    i=$((i + 1))
+    if [ $i -eq $TIMEOUT ]; then
+        echo
+        echo "Timeout while waiting for database to be up"
+        exit 1
+    fi
+    printf "."
+    sleep 1
+done


### PR DESCRIPTION
Acceptance tests was not run in Travis so I configured Travis to start Postgres server in a Docker container (with a Matrix of versions from 8.4 to latest) and enable acceptance tests against it.

By running these tests, I discovered multiple bugs that I fixed:

* The version features flags system was not working because the detected version was not correctly set in the Client struct...
* Database update was not working because of invalid SQL queries (using of statement parameters syntax "$1" but not for parameters...)
* Disable postgresql_extension resource (and associated tests) for Postgres < 9.1 (`CREATE EXTENSION` does not exists before this version)
* Add a replication flag (available for >=9.1)

fix #35 