### PR TITLE
tests: Configure provider before running test

### DIFF
--- a/postgresql/provider_test.go
+++ b/postgresql/provider_test.go
@@ -36,4 +36,9 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("PGUSER"); v == "" {
 		t.Fatal("PGUSER must be set for acceptance tests")
 	}
+
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This should prevent crashes when running tests, e.g.

```
Test ended in panic.

------- Stdout: -------
=== RUN   TestAccPostgresqlDatabase_Update
--- FAIL: TestAccPostgresqlDatabase_Update (0.00s)

------- Stderr: -------
panic: interface conversion: interface {} is nil, not *postgresql.Client [recovered]
	panic: interface conversion: interface {} is nil, not *postgresql.Client

goroutine 20 [running]:
testing.tRunner.func1(0xc00011e300)
	/opt/goenv/versions/1.11.5/src/testing/testing.go:792 +0x387
panic(0xcaf5c0, 0xc000231050)
	/opt/goenv/versions/1.11.5/src/runtime/panic.go:513 +0x1b9
github.com/terraform-providers/terraform-provider-postgresql/postgresql.TestAccPostgresqlDatabase_Update.func1()
	/opt/teamcity-agent/work/476074bb45c53ed2/src/github.com/terraform-providers/terraform-provider-postgresql/postgresql/resource_postgresql_database_test.go:141 +0x94
github.com/terraform-providers/terraform-provider-postgresql/vendor/github.com/hashicorp/terraform/helper/resource.Test(0xf070e0, 0xc00011e300, 0x0, 0xc0002ca2a0, 0xc000230ed0, 0x0, 0x0, 0xdd5450, 0xc00008ea80, 0x2, ...)
	/opt/teamcity-agent/work/476074bb45c53ed2/src/github.com/terraform-providers/terraform-provider-postgresql/vendor/github.com/hashicorp/terraform/helper/resource/testing.go:467 +0x14b2
github.com/terraform-providers/terraform-provider-postgresql/postgresql.TestAccPostgresqlDatabase_Update(0xc00011e300)
	/opt/teamcity-agent/work/476074bb45c53ed2/src/github.com/terraform-providers/terraform-provider-postgresql/postgresql/resource_postgresql_database_test.go:137 +0x575
testing.tRunner(0xc00011e300, 0xdd5338)
	/opt/goenv/versions/1.11.5/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/opt/goenv/versions/1.11.5/src/testing/testing.go:878 +0x35c
```