### PR TITLE
postgresql_role: Don't refresh password from Postgres if not superuser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.2.1 (Unreleased)
+BUG FIXES:
+
+* `provider`: Add a `superuser` setting to fix role password update when provider is not connected as a superuser.
+  ([#66](https://github.com/terraform-providers/terraform-provider-postgresql/pull/66))
+
 ## 0.2.0 (February 21, 2019)
 FEATURES:
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -76,6 +76,7 @@ type Config struct {
 	Username          string
 	Password          string
 	DatabaseUsername  string
+	Superuser         bool
 	SSLMode           string
 	ApplicationName   string
 	Timeout           int
@@ -297,4 +298,15 @@ func (c *Client) featureSupported(name featureName) bool {
 	}
 
 	return fn(c.version)
+}
+
+// isSuperuser returns true if connected user is a Postgres SUPERUSER
+func (c *Client) isSuperuser() (bool, error) {
+	var superuser bool
+
+	if err := c.db.QueryRow("SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER").Scan(&superuser); err != nil {
+		return false, errwrap.Wrapf("could not check if current user is superuser: {{err}}", err)
+	}
+
+	return superuser, nil
 }

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -57,6 +57,14 @@ func Provider() terraform.ResourceProvider {
 				Description: "Database username associated to the connected user (for user name maps)",
 			},
 
+			"superuser": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "Specify if the user to connect as is a Postgres superuser or not." +
+					"If not, some feature might be disabled (e.g.: Refreshing state password from Postgres)",
+			},
+
 			"sslmode": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -145,6 +153,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Username:          d.Get("username").(string),
 		Password:          d.Get("password").(string),
 		DatabaseUsername:  d.Get("database_username").(string),
+		Superuser:         d.Get("superuser").(bool),
 		SSLMode:           sslMode,
 		ApplicationName:   tfAppName(),
 		ConnectTimeoutSec: d.Get("connect_timeout").(int),


### PR DESCRIPTION
Before version 0.2.0,  password update was not correctly updated. Now that it has been fixed (see #54), this breaks `postgresql_role` resource when admin user configured in provider is not a SUPERUSER (permission denied on pg_shadow when trying to refresh password in state). 
Which is the case with RDS for example.

This PR adds a way to specify that admin user is not superuser so password will not be refresh in state.
Password update still works as long as all modifications are done with Terraform (so if passwords are not manually updated in database).

Fix #64 

Configuration example:
```
provider "postgresql" {
  host = "localhost"
  port = "5432"

  username  = "postgres"
  password  = "xxx"
  superuser = false
}

resource "postgresql_role" "test" {
  name     = "test"
  login    = true
  password = "toto"
}