### PR TITLE
Add documentation for `superuser` provider setting

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `username` - (Required) Username for the server connection.
 * `password` - (Optional) Password for the server connection.
 * `database_username` - (Optional) Username of the user in the database if different than connection username (See [user name maps](https://www.postgresql.org/docs/current/auth-username-maps.html)).
+* `superuser` - (Optional) Should be set to `false` if the user to connect is not a PostgreSQL superuser (as is the case in RDS). In this case, some features might be disabled (e.g.: Refreshing state password from database).
 * `sslmode` - (Optional) Set the priority for an SSL connection to the server.
   Valid values for `sslmode` are (note: `prefer` is not supported by Go's
   [`lib/pq`](https://godoc.org/github.com/lib/pq)):


### PR DESCRIPTION
This was added in 0.2.1 via #66 but undocumented.