### PR TITLE
Use literal quotes with VALID UNTIL

### DIFF
--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -209,7 +209,7 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 				case v.(string) == "", strings.ToLower(v.(string)) == "infinity":
 					createOpts = append(createOpts, fmt.Sprintf("%s '%s'", opt.sqlKey, "infinity"))
 				default:
-					createOpts = append(createOpts, fmt.Sprintf("%s %s", opt.sqlKey, pq.QuoteIdentifier(val)))
+					createOpts = append(createOpts, fmt.Sprintf("%s '%s'", opt.sqlKey, pqQuoteLiteral(val)))
 				}
 			default:
 				createOpts = append(createOpts, fmt.Sprintf("%s %s", opt.sqlKey, pq.QuoteIdentifier(val)))

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -50,6 +50,7 @@ resource "postgresql_role" "update_role" {
   name = "update_role"
   login = true
   password = "toto"
+  valid_until = "2019-05-04 12:00:00+00"
 }
 `
 
@@ -74,6 +75,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "password", "toto"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "valid_until", "2019-05-04 12:00:00+00"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -84,6 +86,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "update_role2"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "password", "titi"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "valid_until", "infinity"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},


### PR DESCRIPTION
The timestamp must be enclosed with ` not ".

I attempted to modify the test case, but its tricky with timestamps and I couldn't get past the apply error which always showed a diff on the valid_until due to timestamp formatting issues.