### PR TITLE
grant/default privileges: Fix schema verification.

### DIFF
--- a/postgresql/resource_postgresql_default_privileges_test.go
+++ b/postgresql/resource_postgresql_default_privileges_test.go
@@ -26,7 +26,7 @@ func TestAccPostgresqlDefaultPrivileges(t *testing.T) {
 		database    = "%s"
 		owner       = "%s"
 		role        = "%s"
-		schema      = "public"
+		schema      = "test_schema"
 		object_type = "table"
 		privileges   = ["SELECT"]
 	}
@@ -43,7 +43,7 @@ func TestAccPostgresqlDefaultPrivileges(t *testing.T) {
 				Config: testDPSelect,
 				Check: resource.ComposeTestCheckFunc(
 					func(*terraform.State) error {
-						tables := []string{"test_table"}
+						tables := []string{"test_schema.test_table"}
 						// To test default privileges, we need to create a table
 						// after having apply the state.
 						dropFunc := createTestTables(t, dbSuffix, tables)

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -304,7 +304,7 @@ func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, erro
 
 	// Check the schema exists (the SQL connection needs to be on the right database)
 	pgSchema := d.Get("schema").(string)
-	exists, err = schemaExists(txn, pgSchema)
+	exists, err = schemaExists(dbTxn, pgSchema)
 	if err != nil {
 		return false, err
 	}

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -17,25 +17,25 @@ func TestAccPostgresqlGrant(t *testing.T) {
 	dbSuffix, teardown := setupTestDatabase(t, true, true)
 	defer teardown()
 
-	testTables := []string{"test_table", "test_table2"}
+	testTables := []string{"test_schema.test_table", "test_schema.test_table2"}
 	createTestTables(t, dbSuffix, testTables)
 
 	dbName, roleName := getTestDBNames(dbSuffix)
 	var testGrantSelect = fmt.Sprintf(`
-	resource "postgresql_grant" "test_ro" {
+	resource "postgresql_grant" "test" {
 		database    = "%s"
 		role        = "%s"
-		schema      = "public"
+		schema      = "test_schema"
 		object_type = "table"
 		privileges   = ["SELECT"]
 	}
 	`, dbName, roleName)
 
 	var testGrantSelectInsertUpdate = fmt.Sprintf(`
-	resource "postgresql_grant" "test_ro" {
+	resource "postgresql_grant" "test" {
 		database    = "%s"
 		role        = "%s"
-		schema      = "public"
+		schema      = "test_schema"
 		object_type = "table"
 		privileges   = ["SELECT", "INSERT", "UPDATE"]
 	}
@@ -51,8 +51,8 @@ func TestAccPostgresqlGrant(t *testing.T) {
 			{
 				Config: testGrantSelect,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "1"),
-					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.3138006342", "SELECT"),
 					func(*terraform.State) error {
 						return testCheckTablesPrivileges(t, dbSuffix, testTables, []string{"SELECT"})
 					},
@@ -61,12 +61,23 @@ func TestAccPostgresqlGrant(t *testing.T) {
 			{
 				Config: testGrantSelectInsertUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.#", "3"),
-					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.3138006342", "SELECT"),
-					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.892623219", "INSERT"),
-					resource.TestCheckResourceAttr("postgresql_grant.test_ro", "privileges.1759376126", "UPDATE"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "3"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.3138006342", "SELECT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.892623219", "INSERT"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.1759376126", "UPDATE"),
 					func(*terraform.State) error {
 						return testCheckTablesPrivileges(t, dbSuffix, testTables, []string{"SELECT", "INSERT", "UPDATE"})
+					},
+				),
+			},
+			// Finally reapply the first step to be sure that extra privileges are correctly granted.
+			{
+				Config: testGrantSelect,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "1"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.3138006342", "SELECT"),
+					func(*terraform.State) error {
+						return testCheckTablesPrivileges(t, dbSuffix, testTables, []string{"SELECT"})
 					},
 				),
 			},

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -87,14 +87,18 @@ func setupTestDatabase(t *testing.T, createDB, createRole bool) (string, func())
 
 	dbName, roleName := getTestDBNames(suffix)
 
-	if createDB {
-		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("CREATE DATABASE %s", dbName))
-	}
 	if createRole {
 		dbExecute(t, config.connStr("postgres"), fmt.Sprintf(
 			"CREATE ROLE %s LOGIN ENCRYPTED PASSWORD '%s'",
 			roleName, testRolePassword,
 		))
+	}
+
+	if createDB {
+		dbExecute(t, config.connStr("postgres"), fmt.Sprintf("CREATE DATABASE %s", dbName))
+		// Create a test schema in this new database and grant usage to rolName
+		dbExecute(t, config.connStr(dbName), "CREATE SCHEMA test_schema")
+		dbExecute(t, config.connStr(dbName), fmt.Sprintf("GRANT usage ON SCHEMA test_schema to %s", roleName))
 	}
 
 	return suffix, func() {


### PR DESCRIPTION
To check if `postgresql_grant` or `postgresql_default_privileges` resources exist,
the provider is first checking if database/schema for which they will be applied exist.

For the schema, we created a specific connection on the right database to check
it but it was mistakenly using the wrong connection and was checking if schema exists
on the database defined in provider.

(Basically it was working only for schema `public` which exists by default in all databases)

@multani This is the bug we talked about. Could you have a look please? 