### PR TITLE
Add IF NOT EXISTS to CREATE EXTENSION

### DIFF
--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -66,7 +66,7 @@ func resourcePostgreSQLExtensionCreate(d *schema.ResourceData, meta interface{})
 
 	extName := d.Get(extNameAttr).(string)
 
-	b := bytes.NewBufferString("CREATE EXTENSION IF NOT EXISTS")
+	b := bytes.NewBufferString("CREATE EXTENSION IF NOT EXISTS ")
 	fmt.Fprint(b, pq.QuoteIdentifier(extName))
 
 	if v, ok := d.GetOk(extSchemaAttr); ok {

--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -66,7 +66,7 @@ func resourcePostgreSQLExtensionCreate(d *schema.ResourceData, meta interface{})
 
 	extName := d.Get(extNameAttr).(string)
 
-	b := bytes.NewBufferString("CREATE EXTENSION ")
+	b := bytes.NewBufferString("CREATE EXTENSION IF NOT EXISTS")
 	fmt.Fprint(b, pq.QuoteIdentifier(extName))
 
 	if v, ok := d.GetOk(extSchemaAttr); ok {


### PR DESCRIPTION
The CREATE EXTENSION command will fail if the extension exists. IF NOT EXISTS ignores the error.