### PR TITLE
postgresql_role: add optional attribute to set search_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 
-* `postgresql_role`: Add `searchpath` attribute.
+* `postgresql_role`: Add `search_path` attribute.
   ([#93](https://github.com/terraform-providers/terraform-provider-postgresql/pull/93))
 
 ## 1.2.0 (September 26, 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 1.2.1 (Unreleased)
+
+FEATURES:
+
+* `postgresql_role`: Add `searchpath` attribute.
+  ([#93](https://github.com/terraform-providers/terraform-provider-postgresql/pull/93))
+
 ## 1.2.0 (September 26, 2019)
 
 BUG FIXES:

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -30,7 +30,7 @@ const (
 	roleSuperuserAttr         = "superuser"
 	roleValidUntilAttr        = "valid_until"
 	roleRolesAttr             = "roles"
-	roleSearchPathAttr        = "searchpath"
+	roleSearchPathAttr        = "search_path"
 
 	// Deprecated options
 	roleDepEncryptedAttr = "encrypted"
@@ -450,14 +450,14 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 
 // readSearchPath searches for a search_path entry in the rolconfig array.
 // In case no such value is present, it returns DEFAULT.
-func readSearchPath(roleConfig pq.ByteaArray) string {
+func readSearchPath(roleConfig pq.ByteaArray) []string {
 	for _, v := range roleConfig {
 		config := string(v)
 		if strings.HasPrefix(config, roleSearchPathAttr) {
-			return strings.TrimPrefix(config, roleSearchPathAttr+"=")
+			return strings.Split(strings.TrimPrefix(config, roleSearchPathAttr+"="), ", ")
 		}
 	}
-	return "DEFAULT"
+	return []string{"DEFAULT"}
 }
 
 // readRolePassword reads password either from Postgres if admin user is a superuser
@@ -867,7 +867,7 @@ func alterSearchPath(txn *sql.Tx, d *schema.ResourceData) error {
 	} else {
 		searchPathString = []string{"DEFAULT"}
 	}
-	searchPath := strings.Join(searchPathString[:], ",")
+	searchPath := strings.Join(searchPathString[:], ", ")
 
 	query := fmt.Sprintf(
 		"ALTER ROLE %s SET search_path TO %s", pq.QuoteIdentifier(role), searchPath,

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -862,6 +862,9 @@ func alterSearchPath(txn *sql.Tx, d *schema.ResourceData) error {
 	if len(searchPathInterface) > 0 {
 		searchPathString = make([]string, len(searchPathInterface))
 		for i, searchPathPart := range searchPathInterface {
+			if strings.Contains(searchPathPart.(string), ", ") {
+				return fmt.Errorf("search_path cannot contain `, `: %v", searchPathPart)
+			}
 			searchPathString[i] = pq.QuoteIdentifier(searchPathPart.(string))
 		}
 	} else {

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -30,6 +30,7 @@ const (
 	roleSuperuserAttr         = "superuser"
 	roleValidUntilAttr        = "valid_until"
 	roleRolesAttr             = "roles"
+	roleSearchPathAttr        = "searchpath"
 
 	// Deprecated options
 	roleDepEncryptedAttr = "encrypted"
@@ -70,6 +71,13 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Set:         schema.HashString,
 				MinItems:    0,
 				Description: "Role(s) to grant to this new role",
+			},
+			roleSearchPathAttr: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				MinItems:    1,
+				Description: "Sets the role's search path",
 			},
 			roleEncryptedPassAttr: {
 				Type:        schema.TypeBool,
@@ -270,6 +278,10 @@ func resourcePostgreSQLRoleCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	if err = alterSearchPath(txn, d); err != nil {
+		return err
+	}
+
 	if err = txn.Commit(); err != nil {
 		return errwrap.Wrapf("could not commit transaction: {{err}}", err)
 	}
@@ -352,7 +364,7 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 	var roleSuperuser, roleInherit, roleCreateRole, roleCreateDB, roleCanLogin, roleReplication, roleBypassRLS bool
 	var roleConnLimit int
 	var roleName, roleValidUntil string
-	var roleRoles pq.ByteaArray
+	var roleRoles, roleConfig pq.ByteaArray
 
 	roleID := d.Id()
 
@@ -365,6 +377,7 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 		"rolcanlogin",
 		"rolconnlimit",
 		`COALESCE(rolvaliduntil::TEXT, 'infinity')`,
+		"rolconfig",
 	}
 
 	values := []interface{}{
@@ -377,6 +390,7 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 		&roleCanLogin,
 		&roleConnLimit,
 		&roleValidUntil,
+		&roleConfig,
 	}
 
 	if c.featureSupported(featureReplication) {
@@ -421,6 +435,7 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 	d.Set(roleReplicationAttr, roleReplication)
 	d.Set(roleReplicationAttr, roleBypassRLS)
 	d.Set(roleRolesAttr, pgArrayToSet(roleRoles))
+	d.Set(roleSearchPathAttr, readSearchPath(roleConfig))
 
 	d.SetId(roleName)
 
@@ -431,6 +446,18 @@ func resourcePostgreSQLRoleReadImpl(c *Client, d *schema.ResourceData) error {
 
 	d.Set(rolePasswordAttr, password)
 	return nil
+}
+
+// readSearchPath searches for a search_path entry in the rolconfig array.
+// In case no such value is present, it returns DEFAULT.
+func readSearchPath(roleConfig pq.ByteaArray) string {
+	for _, v := range roleConfig {
+		config := string(v)
+		if strings.HasPrefix(config, roleSearchPathAttr) {
+			return strings.TrimPrefix(config, roleSearchPathAttr+"=")
+		}
+	}
+	return "DEFAULT"
 }
 
 // readRolePassword reads password either from Postgres if admin user is a superuser
@@ -548,6 +575,10 @@ func resourcePostgreSQLRoleUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err = grantRoles(txn, d); err != nil {
+		return err
+	}
+
+	if err = alterSearchPath(txn, d); err != nil {
 		return err
 	}
 
@@ -819,6 +850,30 @@ func grantRoles(txn *sql.Tx, d *schema.ResourceData) error {
 		if _, err := txn.Exec(query); err != nil {
 			return errwrap.Wrapf(fmt.Sprintf("could not grant role %s to %s: {{err}}", grantingRole, role), err)
 		}
+	}
+	return nil
+}
+
+func alterSearchPath(txn *sql.Tx, d *schema.ResourceData) error {
+	role := d.Get(roleNameAttr).(string)
+	searchPathInterface := d.Get(roleSearchPathAttr).([]interface{})
+
+	var searchPathString []string
+	if len(searchPathInterface) > 0 {
+		searchPathString = make([]string, len(searchPathInterface))
+		for i, searchPathPart := range searchPathInterface {
+			searchPathString[i] = pq.QuoteIdentifier(searchPathPart.(string))
+		}
+	} else {
+		searchPathString = []string{"DEFAULT"}
+	}
+	searchPath := strings.Join(searchPathString[:], ",")
+
+	query := fmt.Sprintf(
+		"ALTER ROLE %s SET search_path TO %s", pq.QuoteIdentifier(role), searchPath,
+	)
+	if _, err := txn.Exec(query); err != nil {
+		return errwrap.Wrapf(fmt.Sprintf("could not set search_path %s for %s: {{err}}", searchPath, role), err)
 	}
 	return nil
 }

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -297,7 +297,7 @@ resource "postgresql_role" "role_with_pwd_encr" {
   name = "role_with_pwd_encr"
   login = true
   password = "mypass"
-  encrypted = true
+  encrypted_password = true
 }
 
 resource "postgresql_role" "role_simple" {

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -23,12 +24,12 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 			{
 				Config: testAccPostgresqlRoleConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("myrole2", nil),
+					testAccCheckPostgresqlRoleExists("myrole2", nil, nil),
 					resource.TestCheckResourceAttr("postgresql_role.myrole2", "name", "myrole2"),
 					resource.TestCheckResourceAttr("postgresql_role.myrole2", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.myrole2", "roles.#", "0"),
 
-					testAccCheckPostgresqlRoleExists("role_default", nil),
+					testAccCheckPostgresqlRoleExists("role_default", nil, nil),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "name", "role_default"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "superuser", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "create_database", "false"),
@@ -49,9 +50,11 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "superuser", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "roles.#", "0"),
 
-					testAccCheckPostgresqlRoleExists("sub_role", []string{"myrole2", "role_simple"}),
+					testAccCheckPostgresqlRoleExists("sub_role", []string{"myrole2", "role_simple"}, nil),
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "name", "sub_role"),
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.#", "2"),
+
+					testAccCheckPostgresqlRoleExists("role_with_search_path", nil, []string{"bar", "foo"}),
 
 					// The int part in the attr name is the schema.HashString of the value.
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "roles.719783566", "myrole2"),
@@ -84,6 +87,7 @@ resource "postgresql_role" "update_role" {
   connection_limit = 5
   password = "titi"
   roles = ["${postgresql_role.group_role.name}"]
+  searchpath = ["mysearchpath"]
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -97,7 +101,7 @@ resource "postgresql_role" "update_role" {
 			{
 				Config: configCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("update_role", []string{}),
+					testAccCheckPostgresqlRoleExists("update_role", []string{}, nil),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "update_role"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "connection_limit", "-1"),
@@ -110,7 +114,7 @@ resource "postgresql_role" "update_role" {
 			{
 				Config: configUpdate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("update_role2", []string{"group_role"}),
+					testAccCheckPostgresqlRoleExists("update_role2", []string{"group_role"}, []string{"mysearchpath"}),
 					resource.TestCheckResourceAttr(
 						"postgresql_role.update_role", "name", "update_role2",
 					),
@@ -126,11 +130,12 @@ resource "postgresql_role" "update_role" {
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},
-			// apply again the first one to tests the granted role is correctly revoked
+			// apply the first one again to test that the granted role is correctly
+			// revoked and the search path has been reset to default.
 			{
 				Config: configCreate,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlRoleExists("update_role", []string{}),
+					testAccCheckPostgresqlRoleExists("update_role", []string{}, nil),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "name", "update_role"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "login", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "connection_limit", "-1"),
@@ -165,7 +170,7 @@ func testAccCheckPostgresqlRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckPostgresqlRoleExists(roleName string, grantedRoles []string) resource.TestCheckFunc {
+func testAccCheckPostgresqlRoleExists(roleName string, grantedRoles []string, searchPath []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*Client)
 
@@ -179,7 +184,15 @@ func testAccCheckPostgresqlRoleExists(roleName string, grantedRoles []string) re
 		}
 
 		if grantedRoles != nil {
-			return checkGrantedRoles(client, roleName, grantedRoles)
+			if err := checkGrantedRoles(client, roleName, grantedRoles); err != nil {
+				return err
+			}
+		}
+
+		if searchPath != nil {
+			if err := checkSearchPath(client, roleName, searchPath); err != nil {
+				return err
+			}
 		}
 		return nil
 	}
@@ -243,6 +256,31 @@ func checkGrantedRoles(client *Client, roleName string, expectedRoles []string) 
 	return nil
 }
 
+func checkSearchPath(client *Client, roleName string, expectedSearchPath []string) error {
+	var searchPathStr string
+	err := client.DB().QueryRow(
+		"SELECT (pg_options_to_table(rolconfig)).option_value FROM pg_roles WHERE rolname=$1;",
+		roleName,
+	).Scan(&searchPathStr)
+
+	// The query returns ErrNoRows if the search path hasn't been altered.
+	if err != nil && err == sql.ErrNoRows {
+		searchPathStr = "\"$user\",public"
+	} else if err != nil {
+		return fmt.Errorf("Error reading search_path: %v", err)
+	}
+
+	searchPath := strings.Split(searchPathStr, ", ")
+	sort.Strings(expectedSearchPath)
+	if !reflect.DeepEqual(searchPath, expectedSearchPath) {
+		return fmt.Errorf(
+			"search_path is not equal to expected value. expected %v - got %v",
+			expectedSearchPath, searchPath,
+		)
+	}
+	return nil
+}
+
 var testAccPostgresqlRoleConfig = `
 resource "postgresql_role" "myrole2" {
   name = "myrole2"
@@ -296,6 +334,10 @@ resource "postgresql_role" "sub_role" {
 	]
 }
 
+resource "postgresql_role" "role_with_search_path" {
+  name = "role_with_search_path"
+  searchpath = ["bar","foo"]
+}
 
 resource "postgresql_role" "role_with_superuser" {
   name = "role_with_superuser"

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -87,7 +87,7 @@ resource "postgresql_role" "update_role" {
   connection_limit = 5
   password = "titi"
   roles = ["${postgresql_role.group_role.name}"]
-  searchpath = ["mysearchpath"]
+  search_path = ["mysearchpath"]
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -265,7 +265,7 @@ func checkSearchPath(client *Client, roleName string, expectedSearchPath []strin
 
 	// The query returns ErrNoRows if the search path hasn't been altered.
 	if err != nil && err == sql.ErrNoRows {
-		searchPathStr = "\"$user\",public"
+		searchPathStr = "\"$user\", public"
 	} else if err != nil {
 		return fmt.Errorf("Error reading search_path: %v", err)
 	}
@@ -336,7 +336,7 @@ resource "postgresql_role" "sub_role" {
 
 resource "postgresql_role" "role_with_search_path" {
   name = "role_with_search_path"
-  searchpath = ["bar","foo"]
+  search_path = ["bar", "foo"]
 }
 
 resource "postgresql_role" "role_with_superuser" {

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -87,7 +87,7 @@ resource "postgresql_role" "my_replication_role" {
 
 * `roles` - (Optional) Defines list of roles which will be granted to this new role.
 
-* `searchpath` - (Optional) Alters the search path of this new role.
+* `search_path` - (Optional) Alters the search path of this new role.
 
 * `valid_until` - (Optional) Defines the date and time after which the role's
   password is no longer valid.  Established connections past this `valid_time`

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -87,7 +87,9 @@ resource "postgresql_role" "my_replication_role" {
 
 * `roles` - (Optional) Defines list of roles which will be granted to this new role.
 
-* `search_path` - (Optional) Alters the search path of this new role.
+* `search_path` - (Optional) Alters the search path of this new role. Note that
+  due to limitations in the implementation, values cannot contain the substring
+  `", "`.
 
 * `valid_until` - (Optional) Defines the date and time after which the role's
   password is no longer valid.  Established connections past this `valid_time`

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -87,6 +87,8 @@ resource "postgresql_role" "my_replication_role" {
 
 * `roles` - (Optional) Defines list of roles which will be granted to this new role.
 
+* `searchpath` - (Optional) Alters the search path of this new role.
+
 * `valid_until` - (Optional) Defines the date and time after which the role's
   password is no longer valid.  Established connections past this `valid_time`
   will have to be manually terminated.  This value corresponds to a PostgreSQL


### PR DESCRIPTION
This PR adds a new attribute to `postgresql_role` that allows one to set the search path of the new role. Let me know if there's anything I missed or can improve!