### PR TITLE
resource_postgresql_schema: Add database optional parameter

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -208,3 +208,13 @@ func deferredRollback(txn *sql.Tx) {
 		log.Printf("[ERR] could not rollback transaction: %v", err)
 	}
 }
+
+func getDatabase(d *schema.ResourceData, client *Client) string {
+	database := client.databaseName
+
+	if v, ok := d.GetOk(extDatabaseAttr); ok {
+		database = v.(string)
+	}
+
+	return database
+}


### PR DESCRIPTION
Hello,

For now `postgresql_schema` resource use database parameter set in provider definition. If database do not exist (ex: the first time) postgresql provider fail.
In other postgresql resources we need to pass database parameter at resource level.

This change add database parameter on `resource_postgresql_schema`.