### PR TITLE
Trust `expected_version` if provided

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -131,10 +131,15 @@ func (c *Config) NewClient(database string) (*Client, error) {
 		db.SetMaxIdleConns(0)
 		db.SetMaxOpenConns(c.MaxConns)
 
-		version, err := fingerprintCapabilities(db)
-		if err != nil {
-			db.Close()
-			return nil, errwrap.Wrapf("error detecting capabilities: {{err}}", err)
+		defaultVersion, _ := semver.Parse(defaultExpectedPostgreSQLVersion)
+		version := &c.ExpectedVersion
+		if defaultVersion.Equals(c.ExpectedVersion) {
+			// Version hint not set by user, need to fingerprint
+			version, err = fingerprintCapabilities(db)
+			if err != nil {
+				db.Close()
+				return nil, errwrap.Wrapf("error detecting capabilities: {{err}}", err)
+			}
 		}
 
 		dbEntry = dbRegistryEntry{

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -121,7 +121,7 @@ func validateConnTimeout(v interface{}, key string) (warnings []string, errors [
 }
 
 func validateExpectedVersion(v interface{}, key string) (warnings []string, errors []error) {
-	if _, err := semver.Parse(v.(string)); err != nil {
+	if _, err := semver.ParseTolerant(v.(string)); err != nil {
 		errors = append(errors, fmt.Errorf("invalid version (%q): %v", v.(string), err))
 	}
 	return
@@ -146,7 +146,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 	versionStr := d.Get("expected_version").(string)
-	version, _ := semver.Parse(versionStr)
+	version, _ := semver.ParseTolerant(versionStr)
 
 	config := Config{
 		Host:              d.Get("host").(string),


### PR DESCRIPTION
Fixes #2, perhaps controversially.

The reason it's not currently possible to provision, e.g., an RDS instance and modify it with a `postgresql_*` resource is that the `postgresql` provider attempts to parse the PostgreSQL version by connecting to the database during the planning phase.

This pull request allows the user to prevent this from happening by specifying the version directly via the existing `expected_version` parameter. In practice, you would do something like:
```hcl
resource "aws_db_instance" "this" {
  [...]
}

provider "postgresql" {
  [...]
  expected_version = aws_db_instance.this.engine_version
}
```

The behavior of the provider if `expected_version` is not supplied remains the same.