### PR TITLE
[add] set statement_timeout to role

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -37,6 +37,14 @@ func validateConnLimit(v interface{}, key string) (warnings []string, errors []e
 	return
 }
 
+func validateStatementTimeout(v interface{}, key string) (warnings []string, errors []error) {
+	value := v.(int)
+	if value < 0 {
+		errors = append(errors, fmt.Errorf("%s can not be less than 0", key))
+	}
+	return
+}
+
 func isRoleMember(db QueryAble, role, member string) (bool, error) {
 	var _rez int
 	err := db.QueryRow(

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -489,7 +489,7 @@ func readStatementTimeout(roleConfig pq.ByteaArray) (int, error) {
 			var result = strings.Split(strings.TrimPrefix(config, roleStatementTimeoutAttr+"="), ", ")
 			res, err := strconv.Atoi(result[0])
 			if err != nil {
-				return -1, err
+				return -1, errwrap.Wrapf("Error reading statement_timeout: {{err}}", err)
 			}
 			return res, nil
 		}

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -43,6 +43,7 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "valid_until", "infinity"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_drop_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_reassign_owned", "false"),
+					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "statement_timeout", "0"),
 
 					resource.TestCheckResourceAttr("postgresql_role.role_with_create_database", "name", "role_with_create_database"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_create_database", "create_database", "true"),
@@ -88,6 +89,7 @@ resource "postgresql_role" "update_role" {
   password = "titi"
   roles = ["${postgresql_role.group_role.name}"]
   search_path = ["mysearchpath"]
+  statement_timeout = 30000
 }
 `
 	resource.Test(t, resource.TestCase{
@@ -109,6 +111,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "valid_until", "2099-05-04 12:00:00+00"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.#", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.#", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -130,6 +133,7 @@ resource "postgresql_role" "update_role" {
 					),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.#", "1"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.0", "mysearchpath"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "30000"),
 					testAccCheckRoleCanLogin(t, "update_role2", "titi"),
 				),
 			},
@@ -145,6 +149,7 @@ resource "postgresql_role" "update_role" {
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "password", "toto"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "roles.#", "0"),
 					resource.TestCheckResourceAttr("postgresql_role.update_role", "search_path.#", "0"),
+					resource.TestCheckResourceAttr("postgresql_role.update_role", "statement_timeout", "0"),
 					testAccCheckRoleCanLogin(t, "update_role", "toto"),
 				),
 			},
@@ -323,6 +328,7 @@ resource "postgresql_role" "role_with_defaults" {
   skip_drop_role = false
   skip_reassign_owned = false
   valid_until = "infinity"
+  statement_timeout = 0
 }
 
 resource "postgresql_role" "role_with_create_database" {


### PR DESCRIPTION
set `statement_timeout` to role


> statement_timeout (integer)
Abort any statement that takes more than the specified number of milliseconds, starting from the time the command arrives at the server from the client.