### PR TITLE
postgresql_schema: Add drop_cascade option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ FEATURES:
   ([#103](https://github.com/terraform-providers/terraform-provider-postgresql/pull/103))
   This allows to disable the version detection which requires a database connection, so plan on empty state does not require a connection.
 
+* `postgresql_schema`: Add `drop_cascade` attribute.
+  ([#108](https://github.com/terraform-providers/terraform-provider-postgresql/pull/108))
+
 
 ## 1.3.0 (November 01, 2019)
 

--- a/website/docs/r/postgresql_schema.html.markdown
+++ b/website/docs/r/postgresql_schema.html.markdown
@@ -59,6 +59,7 @@ resource "postgresql_schema" "my_schema" {
   database instance where it is configured.
 * `owner` - (Optional) The ROLE who owns the schema.
 * `if_not_exists` - (Optional) When true, use the existing schema if it exists. (Default: true)
+* `drop_cascade` - (Optional) When true, will also drop all the objects that are contained in the schema. (Default: false)
 * `policy` - (Optional) Can be specified multiple times for each policy.  Each
     policy block supports fields documented below.
 


### PR DESCRIPTION
This allows to delete cascade all dependent objects while deleting a schema.

fix #101 