### PR TITLE
Update README with link to Terraform doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ $ make build
 
 Using the provider
 ----------------------
-## Fill in for each provider
+
+Usage examples can be found in the Terraform [provider documentation](https://www.terraform.io/docs/providers/postgresql/index.html)
 
 Developing the Provider
 ---------------------------


### PR DESCRIPTION
Update the "use" section to link to the official provider usage documentation, instead of a placeholder TODO