### PR TITLE
Add missing documentation specifying the database for `postgresql_schema`

### DIFF
--- a/website/docs/r/postgresql_schema.html.markdown
+++ b/website/docs/r/postgresql_schema.html.markdown
@@ -57,6 +57,7 @@ resource "postgresql_schema" "my_schema" {
 
 * `name` - (Required) The name of the schema. Must be unique in the PostgreSQL
   database instance where it is configured.
+* `database` - (Optional) The DATABASE in which where this schema will be created. (Default: The database used by your `provider` configuration)
 * `owner` - (Optional) The ROLE who owns the schema.
 * `if_not_exists` - (Optional) When true, use the existing schema if it exists. (Default: true)
 * `drop_cascade` - (Optional) When true, will also drop all the objects that are contained in the schema. (Default: false)


### PR DESCRIPTION
Hey there!

The current documentation for `postgres_schema` doesn't reference how to change the database that the schema is in. I assumed that it would use the `provider` configuration to infer this but really it just defaults to `postgres` and it can be overridden via configuration so I just added some documentation for this feature.

Cheers