### PR TITLE
Replace unnecessary validation functions with validators from the plugin SDK

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -29,22 +29,6 @@ func pqQuoteLiteral(in string) string {
 	return in
 }
 
-func validateConnLimit(v interface{}, key string) (warnings []string, errors []error) {
-	value := v.(int)
-	if value < -1 {
-		errors = append(errors, fmt.Errorf("%s can not be less than -1", key))
-	}
-	return
-}
-
-func validateStatementTimeout(v interface{}, key string) (warnings []string, errors []error) {
-	value := v.(int)
-	if value < 0 {
-		errors = append(errors, fmt.Errorf("%s can not be less than 0", key))
-	}
-	return
-}
-
 func isRoleMember(db QueryAble, role, member string) (bool, error) {
 	var _rez int
 	err := db.QueryRow(

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/lib/pq"
 )
 
@@ -88,7 +89,7 @@ func resourcePostgreSQLDatabase() *schema.Resource {
 				Optional:     true,
 				Default:      -1,
 				Description:  "How many concurrent connections can be made to this database",
-				ValidateFunc: validateConnLimit,
+				ValidateFunc: validation.IntAtLeast(-1),
 			},
 			dbAllowConnsAttr: {
 				Type:        schema.TypeBool,

--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/lib/pq"
 )
 
@@ -98,7 +99,7 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Optional:     true,
 				Default:      -1,
 				Description:  "How many concurrent connections can be made with this role",
-				ValidateFunc: validateConnLimit,
+				ValidateFunc: validation.IntAtLeast(-1),
 			},
 			roleSuperuserAttr: {
 				Type:        schema.TypeBool,
@@ -158,7 +159,7 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Description:  "Abort any statement that takes more than the specified number of milliseconds",
-				ValidateFunc: validateStatementTimeout,
+				ValidateFunc: validation.IntAtLeast(0),
 			},
 		},
 	}

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/lib/pq"
-	"github.com/sean-/postgresql-acl"
+	acl "github.com/sean-/postgresql-acl"
 )
 
 const (


### PR DESCRIPTION
The plugin SDK provides helper validation functions that are well tested and used in a lot of places.
In general we should prefer to use these where possible instead of rolling our own functions that do the same thing.

I noticed this after the recent release and looking at https://github.com/terraform-providers/terraform-provider-postgresql/pull/105 but only after it had been merged.

Output from `terraform validate` after this change:
```
Error: expected connection_limit to be at least (-1), got -2

  on main.tf line 1, in resource "postgresql_role" "my_role":
   1: resource "postgresql_role" "my_role" {



Error: expected statement_timeout to be at least (0), got -1

  on main.tf line 1, in resource "postgresql_role" "my_role":
   1: resource "postgresql_role" "my_role" {
```

which is arguably slightly less nice than the existing output:
```
Error: connection_limit can not be less than -1

  on main.tf line 1, in resource "postgresql_role" "my_role":
   1: resource "postgresql_role" "my_role" {
```
but does so without duplicating code elsewhere so feel like this is a better approach.

`validatePrivileges` can probably also be refactored to use the `StringInSlice` validator but wanted to check if people were happy with replacing the validators here with the ones from the plugin SDK before going further.