### PR TITLE
Implement grants on database

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -105,6 +105,7 @@ func sliceContainsStr(haystack []string, needle string) bool {
 // allowedPrivileges is the list of privileges allowed per object types in Postgres.
 // see: https://www.postgresql.org/docs/current/sql-grant.html
 var allowedPrivileges = map[string][]string{
+	"database": []string{"ALL", "CREATE", "CONNECT", "TEMPORARY", "TEMP"},
 	"table":    []string{"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
 	"sequence": []string{"ALL", "USAGE", "SELECT", "UPDATE"},
 }

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -93,7 +93,7 @@ func resourcePostgreSQLDefaultPrivilegesRead(d *schema.ResourceData, meta interf
 }
 
 func resourcePostgreSQLDefaultPrivilegesCreate(d *schema.ResourceData, meta interface{}) error {
-	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+	if err := validatePrivileges(d); err != nil {
 		return err
 	}
 
@@ -271,7 +271,6 @@ func revokeRoleDefaultPrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 		return errwrap.Wrapf("could not revoke default privileges: {{err}}", err)
 	}
 	return nil
-
 }
 
 func generateDefaultPrivilegesID(d *schema.ResourceData) string {

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -14,20 +14,18 @@ import (
 	"github.com/lib/pq"
 )
 
+var allowedObjectTypes = []string{
+	"database",
+	"table",
+	"sequence",
+}
+
 var objectTypes = map[string]string{
-	"database": "d",
 	"table":    "r",
 	"sequence": "S",
 }
 
 func resourcePostgreSQLGrant() *schema.Resource {
-
-	allowedObjectTypes := make([]string, 0, len(objectTypes))
-
-	for k := range objectTypes {
-		allowedObjectTypes = append(allowedObjectTypes, k)
-	}
-
 	return &schema.Resource{
 		Create: resourcePostgreSQLGrantCreate,
 		// As create revokes and grants we can use it to update too
@@ -50,7 +48,7 @@ func resourcePostgreSQLGrant() *schema.Resource {
 			},
 			"schema": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				ForceNew:    true,
 				Description: "The database schema to grant privileges on for this role",
 			},
@@ -122,7 +120,7 @@ func resourcePostgreSQLGrantCreate(d *schema.ResourceData, meta interface{}) err
 		)
 	}
 
-	if err := validatePrivileges(d.Get("object_type").(string), d.Get("privileges").(*schema.Set).List()); err != nil {
+	if err := validatePrivileges(d); err != nil {
 		return err
 	}
 
@@ -193,7 +191,38 @@ func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
+func readDatabaseRolePriviges(txn *sql.Tx, d *schema.ResourceData) error {
+	query := `
+SELECT privilege_type
+FROM (
+	SELECT (aclexplode(datacl)).* FROM pg_database WHERE datname=$1
+) as privileges
+JOIN pg_roles ON grantee = pg_roles.oid WHERE rolname = $2
+`
+
+	privileges := []string{}
+	rows, err := txn.Query(query, d.Get("database"), d.Get("role"))
+	if err != nil {
+		return errwrap.Wrapf("could not read database privileges: {{err}}", err)
+	}
+
+	for rows.Next() {
+		var privilegeType string
+		if err := rows.Scan(&privilegeType); err != nil {
+			return errwrap.Wrapf("could not scan database privilege: {{err}}", err)
+		}
+		privileges = append(privileges, privilegeType)
+	}
+
+	d.Set("privileges", privileges)
+	return nil
+}
+
 func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
+	if d.Get("object_type").(string) == "database" {
+		return readDatabaseRolePriviges(txn, d)
+	}
+
 	// This returns, for the specified role (rolname),
 	// the list of all object of the specified type (relkind) in the specified schema (namespace)
 	// with the list of the currently applied privileges (aggregation of privilege_type)
@@ -312,8 +341,10 @@ func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 
 func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	query := createRevokeQuery(d)
-	_, err := txn.Exec(query)
-	return err
+	if _, err := txn.Exec(query); err != nil {
+		return errwrap.Wrapf("could not execute revoke query: {{err}}", err)
+	}
+	return nil
 }
 
 func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, error) {
@@ -345,30 +376,37 @@ func checkRoleDBSchemaExists(client *Client, d *schema.ResourceData) (bool, erro
 		return false, nil
 	}
 
-	// Connect on this database to check if schema exists
-	dbTxn, err := startTransaction(client, database)
-	if err != nil {
-		return false, err
-	}
-	defer dbTxn.Rollback()
+	if d.Get("object_type").(string) != "database" {
+		// Connect on this database to check if schema exists
+		dbTxn, err := startTransaction(client, database)
+		if err != nil {
+			return false, err
+		}
+		defer dbTxn.Rollback()
 
-	// Check the schema exists (the SQL connection needs to be on the right database)
-	pgSchema := d.Get("schema").(string)
-	exists, err = schemaExists(dbTxn, pgSchema)
-	if err != nil {
-		return false, err
-	}
-	if !exists {
-		log.Printf("[DEBUG] schema %s does not exists", pgSchema)
-		return false, nil
+		// Check the schema exists (the SQL connection needs to be on the right database)
+		pgSchema := d.Get("schema").(string)
+		exists, err = schemaExists(dbTxn, pgSchema)
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			log.Printf("[DEBUG] schema %s does not exists", pgSchema)
+			return false, nil
+		}
 	}
 
 	return true, nil
 }
 
 func generateGrantID(d *schema.ResourceData) string {
-	return strings.Join([]string{
-		d.Get("role").(string), d.Get("database").(string),
-		d.Get("schema").(string), d.Get("object_type").(string),
-	}, "_")
+	parts := []string{d.Get("role").(string), d.Get("database").(string)}
+
+	objectType := d.Get("object_type").(string)
+	if objectType != "database" {
+		parts = append(parts, d.Get("schema").(string))
+	}
+	parts = append(parts, objectType)
+
+	return strings.Join(parts, "_")
 }

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -5,8 +5,135 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/lib/pq"
 )
+
+func TestCreateGrantQuery(t *testing.T) {
+	var databaseName = "foo"
+	var roleName = "bar"
+
+	cases := []struct {
+		resource   *schema.ResourceData
+		privileges []string
+		expected   string
+	}{
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "table",
+				"schema":      databaseName,
+				"role":        roleName,
+			}),
+			privileges: []string{"SELECT"},
+			expected:   fmt.Sprintf("GRANT SELECT ON ALL TABLES IN SCHEMA %s TO %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "sequence",
+				"schema":      databaseName,
+				"role":        roleName,
+			}),
+			privileges: []string{"SELECT"},
+			expected:   fmt.Sprintf("GRANT SELECT ON ALL SEQUENCES IN SCHEMA %s TO %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type":       "TABLE",
+				"schema":            databaseName,
+				"role":              roleName,
+				"with_grant_option": true,
+			}),
+			privileges: []string{"SELECT", "INSERT", "UPDATE"},
+			expected:   fmt.Sprintf("GRANT SELECT,INSERT,UPDATE ON ALL TABLES IN SCHEMA %s TO %s WITH GRANT OPTION", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "database",
+				"database":    databaseName,
+				"role":        roleName,
+			}),
+			privileges: []string{"CREATE"},
+			expected:   fmt.Sprintf("GRANT CREATE ON DATABASE %s TO %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "database",
+				"database":    databaseName,
+				"role":        roleName,
+			}),
+			privileges: []string{"CREATE", "CONNECT"},
+			expected:   fmt.Sprintf("GRANT CREATE,CONNECT ON DATABASE %s TO %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type":       "DATABASE",
+				"database":          databaseName,
+				"role":              roleName,
+				"with_grant_option": true,
+			}),
+			privileges: []string{"ALL PRIVILEGES"},
+			expected:   fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE %s TO %s WITH GRANT OPTION", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+	}
+
+	for _, c := range cases {
+		out := createGrantQuery(c.resource, c.privileges)
+		if out != c.expected {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateRevokeQuery(t *testing.T) {
+	var databaseName = "foo"
+	var roleName = "bar"
+
+	cases := []struct {
+		resource *schema.ResourceData
+		expected string
+	}{
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "table",
+				"schema":      databaseName,
+				"role":        roleName,
+			}),
+			expected: fmt.Sprintf("REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %s FROM %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "sequence",
+				"schema":      databaseName,
+				"role":        roleName,
+			}),
+			expected: fmt.Sprintf("REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %s FROM %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "database",
+				"database":    databaseName,
+				"role":        roleName,
+			}),
+			expected: fmt.Sprintf("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "DATABASE",
+				"database":    databaseName,
+				"role":        roleName,
+			}),
+			expected: fmt.Sprintf("REVOKE ALL PRIVILEGES ON DATABASE %s FROM %s", pq.QuoteIdentifier(databaseName), pq.QuoteIdentifier(roleName)),
+		},
+	}
+
+	for _, c := range cases {
+		out := createRevokeQuery(c.resource)
+		if out != c.expected {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
 
 func TestAccPostgresqlGrant(t *testing.T) {
 	skipIfNotAcc(t)
@@ -78,6 +205,48 @@ func TestAccPostgresqlGrant(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.3138006342", "SELECT"),
 					func(*terraform.State) error {
 						return testCheckTablesPrivileges(t, dbSuffix, testTables, []string{"SELECT"})
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccPostgresqlGrantDatabase(t *testing.T) {
+	skipIfNotAcc(t)
+
+	// We have to create the database outside of resource.Test
+	// because we need to create tables to assert that grant are correctly applied
+	// and we don't have this resource yet
+	dbSuffix, teardown := setupTestDatabase(t, true, true)
+	defer teardown()
+
+	dbName, roleName := getTestDBNames(dbSuffix)
+	var testGrantSelect = fmt.Sprintf(`
+	resource "postgresql_grant" "test" {
+		database           = "%s"
+		role               = "%s"
+		schema             = "test_schema"
+		object_type        = "database"
+		privileges         = ["CONNECT", "CREATE"]
+		with_grant_option  = true
+	}
+	`, dbName, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featurePrivileges)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGrantSelect,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("postgresql_grant.test", "privileges.#", "2"),
+					resource.TestCheckResourceAttr("postgresql_grant.test", "with_grant_option", "true"),
+					func(*terraform.State) error {
+						return testCheckDatabasesPrivileges(t, dbSuffix, []string{"CONNECT"})
 					},
 				),
 			},

--- a/postgresql/utils_test.go
+++ b/postgresql/utils_test.go
@@ -192,3 +192,28 @@ func testCheckTablesPrivileges(t *testing.T, dbSuffix string, tables []string, a
 	}
 	return nil
 }
+
+func testCheckDatabasesPrivileges(t *testing.T, dbSuffix string, allowedPrivileges []string) error {
+	config := getTestConfig(t)
+	dbName, roleName := getTestDBNames(dbSuffix)
+
+	// Connect as the test role
+	config.Username = roleName
+	config.Password = testRolePassword
+
+	db, err := sql.Open("postgres", config.connStr(dbName))
+	if err != nil {
+		t.Fatalf("could not open connection pool for db %s: %v", dbName, err)
+	}
+	defer db.Close()
+
+	queries := map[string]string{
+		"CREATE": fmt.Sprintf("CREATE DATABASE foo"),
+	}
+
+	for _, query := range queries {
+		db.Exec(query)
+	}
+
+	return nil
+}


### PR DESCRIPTION
I'm following @tgermain's [comment](https://github.com/terraform-providers/terraform-provider-postgresql/issues/85#issuecomment-581424768) (we work together) regarding the proposal to handle `GRANT` on databases (in addition to sequences and tables).

I took the liberty to move the query string creation (for both grant and revoke queries) into two dedicated functions and write unit test for them (although I'm a test newbie). Feel free to discard that if you find it irrelevant.