### PR TITLE
Provider Configuration: Support SSL Client Certificates

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -251,6 +251,14 @@ func (c *Config) connStr(database string) string {
 		if c.featureSupported(featureFallbackApplicationName) {
 			logValues = append(logValues, quote(c.ApplicationName))
 		}
+		if c.SSLClientCert != nil {
+			logValues = append(
+				logValues,
+				quote(c.SSLClientCert.CertificatePath),
+				quote(c.SSLClientCert.KeyPath),
+				quote(c.SSLClientCert.RootKeyPath),
+			)
+		}
 
 		logDSN := fmt.Sprintf(dsnFmt, logValues...)
 		log.Printf("[INFO] PostgreSQL DSN: `%s`", logDSN)

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -76,7 +76,6 @@ var (
 type ClientCertificateConfig struct {
 	CertificatePath string
 	KeyPath         string
-	RootKeyPath     string
 }
 
 // Config - provider config
@@ -94,6 +93,7 @@ type Config struct {
 	MaxConns          int
 	ExpectedVersion   semver.Version
 	SSLClientCert     *ClientCertificateConfig
+	SSLRootCertPath   string
 }
 
 // Client struct holding connection string
@@ -202,8 +202,10 @@ func (c *Config) connStr(database string) string {
 				dsnFmtParts,
 				"sslcert=%s",
 				"sslkey=%s",
-				"sslrootcert=%s",
 			)
+		}
+		if c.SSLRootCertPath != "" {
+			dsnFmtParts = append(dsnFmtParts, "sslrootcert=%s")
 		}
 
 		dsnFmt = strings.Join(dsnFmtParts, " ")
@@ -256,8 +258,10 @@ func (c *Config) connStr(database string) string {
 				logValues,
 				quote(c.SSLClientCert.CertificatePath),
 				quote(c.SSLClientCert.KeyPath),
-				quote(c.SSLClientCert.RootKeyPath),
 			)
+		}
+		if c.SSLRootCertPath != "" {
+			logValues = append(logValues, quote(c.SSLRootCertPath))
 		}
 
 		logDSN := fmt.Sprintf(dsnFmt, logValues...)
@@ -283,9 +287,12 @@ func (c *Config) connStr(database string) string {
 				connValues,
 				quote(c.SSLClientCert.CertificatePath),
 				quote(c.SSLClientCert.KeyPath),
-				quote(c.SSLClientCert.RootKeyPath),
 			)
 		}
+		if c.SSLRootCertPath != "" {
+			connValues = append(connValues, quote(c.SSLRootCertPath))
+		}
+
 		connStr = fmt.Sprintf(dsnFmt, connValues...)
 	}
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -289,7 +289,6 @@ func (c *Config) connStr(database string) string {
 		connStr = fmt.Sprintf(dsnFmt, connValues...)
 	}
 
-	fmt.Printf("connection string: `%s`", connStr)
 	return connStr
 }
 

--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -73,6 +73,12 @@ var (
 	}
 )
 
+type ClientCertificateConfig struct {
+	CertificatePath string
+	KeyPath         string
+	RootKeyPath     string
+}
+
 // Config - provider config
 type Config struct {
 	Host              string
@@ -87,6 +93,7 @@ type Config struct {
 	ConnectTimeoutSec int
 	MaxConns          int
 	ExpectedVersion   semver.Version
+	SSLClientCert     *ClientCertificateConfig
 }
 
 // Client struct holding connection string
@@ -190,6 +197,14 @@ func (c *Config) connStr(database string) string {
 		if c.featureSupported(featureFallbackApplicationName) {
 			dsnFmtParts = append(dsnFmtParts, "fallback_application_name=%s")
 		}
+		if c.SSLClientCert != nil {
+			dsnFmtParts = append(
+				dsnFmtParts,
+				"sslcert=%s",
+				"sslkey=%s",
+				"sslrootcert=%s",
+			)
+		}
 
 		dsnFmt = strings.Join(dsnFmtParts, " ")
 	}
@@ -255,9 +270,18 @@ func (c *Config) connStr(database string) string {
 		if c.featureSupported(featureFallbackApplicationName) {
 			connValues = append(connValues, quote(c.ApplicationName))
 		}
+		if c.SSLClientCert != nil {
+			connValues = append(
+				connValues,
+				quote(c.SSLClientCert.CertificatePath),
+				quote(c.SSLClientCert.KeyPath),
+				quote(c.SSLClientCert.RootKeyPath),
+			)
+		}
 		connStr = fmt.Sprintf(dsnFmt, connValues...)
 	}
 
+	fmt.Printf("connection string: `%s`", connStr)
 	return connStr
 }
 

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -76,6 +76,32 @@ func Provider() terraform.ResourceProvider {
 				Optional:   true,
 				Deprecated: "Rename PostgreSQL provider `ssl_mode` attribute to `sslmode`",
 			},
+			"clientcert": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "SSL client certificate if required by the database.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cert": {
+							Type:        schema.TypeString,
+							Description: "The SSL client certificate file path. The file must contain PEM encoded data.",
+							Required:    true,
+						},
+						"key": {
+							Type:        schema.TypeString,
+							Description: "The SSL client certificate private key file path. The file must contain PEM encoded data.",
+							Required:    true,
+						},
+						"rootcert": {
+							Type:        schema.TypeString,
+							Description: "The SSL server root certificate file path. The file must contain PEM encoded data.",
+							Required:    true,
+						},
+					},
+				},
+				MaxItems: 1,
+			},
+
 			"connect_timeout": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -160,6 +186,16 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ConnectTimeoutSec: d.Get("connect_timeout").(int),
 		MaxConns:          d.Get("max_connections").(int),
 		ExpectedVersion:   version,
+	}
+
+	if value, ok := d.GetOk("clientcert"); ok {
+		if spec, ok := value.([]interface{})[0].(map[string]interface{}); ok {
+			config.SSLClientCert = &ClientCertificateConfig{
+				CertificatePath: spec["cert"].(string),
+				KeyPath:         spec["key"].(string),
+				RootKeyPath:     spec["rootcert"].(string),
+			}
+		}
 	}
 
 	client, err := config.NewClient(d.Get("database").(string))

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -92,14 +92,14 @@ func Provider() terraform.ResourceProvider {
 							Description: "The SSL client certificate private key file path. The file must contain PEM encoded data.",
 							Required:    true,
 						},
-						"rootcert": {
-							Type:        schema.TypeString,
-							Description: "The SSL server root certificate file path. The file must contain PEM encoded data.",
-							Required:    true,
-						},
 					},
 				},
 				MaxItems: 1,
+			},
+			"sslrootcert": {
+				Type:        schema.TypeString,
+				Description: "The SSL server root certificate file path. The file must contain PEM encoded data.",
+				Optional:    true,
 			},
 
 			"connect_timeout": {
@@ -186,6 +186,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ConnectTimeoutSec: d.Get("connect_timeout").(int),
 		MaxConns:          d.Get("max_connections").(int),
 		ExpectedVersion:   version,
+		SSLRootCertPath:   d.Get("sslrootcert").(string),
 	}
 
 	if value, ok := d.GetOk("clientcert"); ok {
@@ -193,7 +194,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			config.SSLClientCert = &ClientCertificateConfig{
 				CertificatePath: spec["cert"].(string),
 				KeyPath:         spec["key"].(string),
-				RootKeyPath:     spec["rootcert"].(string),
 			}
 		}
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -26,6 +26,22 @@ provider "postgresql" {
 }
 ```
 
+An SSL client certificate can be configured using the `clientcert` sub-resource.
+
+``` hcl
+provider "postgresql" {
+  host            = "postgres_server_ip"
+  port            = 5432
+  database        = "postgres"
+  username        = "postgres_user"
+  password        = "postgres_password"
+  sslmode         = "require"
+  clientcert {
+    cert = "/path/to/public-certificate.pem"
+    key  = "/path/to/private-key.pem"
+  }
+```
+
 Configuring multiple servers can be done by specifying the alias option.
 
 ```hcl
@@ -74,6 +90,10 @@ The following arguments are supported:
     * verify-full - Always SSL (verify that the certification presented by the server was signed by a trusted CA and the server host name matches the one in the certificate)
   Additional information on the options and their implications can be seen
   [in the `libpq(3)` SSL guide](http://www.postgresql.org/docs/current/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION).
+* `clientcert` - (Optional) - Configure the SSL client certificate.
+  * `cert` - (Requrired) - The SSL client certificate file path. The file must contain PEM encoded data.
+  * `key` - (Required) - The SSL client certificate private key file path. The file must contain PEM encoded data.
+* `sslrootcert` - (Optional) - The SSL server root certificate file path. The file must contain PEM encoded data.
 * `connect_timeout` - (Optional) Maximum wait for connection, in seconds. The
   default is `180s`.  Zero or not specified means wait indefinitely.
 * `max_connections` - (Optional) Set the maximum number of open connections to


### PR DESCRIPTION
Fixes: #49 

Adds a new optional nested block to the provider configuration for SSL client certificate files paths.

Example:

```hcl
provider "postgresql" {
  host = "localhost"

  clientcert {
    cert     = "client-cert.pem"
    key      = "client-key.pem"
  }
  sslrootcert = "server-ca.pem"
}
```

I tried to match the coding conventions of the project as best as I understand them.  I'm happy to adjust the property names if there are preferences from reviewers.