### PR TITLE
[resource_postgresql_default_privileges] add support for types default privileges

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -103,6 +103,7 @@ var allowedPrivileges = map[string][]string{
 	"table":    []string{"ALL", "SELECT", "INSERT", "UPDATE", "DELETE", "TRUNCATE", "REFERENCES", "TRIGGER"},
 	"sequence": []string{"ALL", "USAGE", "SELECT", "UPDATE"},
 	"function": []string{"ALL", "EXECUTE"},
+	"type":     []string{"ALL", "USAGE"},
 }
 
 // validatePrivileges checks that privileges to apply are allowed for this object type.

--- a/postgresql/resource_postgresql_default_privileges.go
+++ b/postgresql/resource_postgresql_default_privileges.go
@@ -53,8 +53,9 @@ func resourcePostgreSQLDefaultPrivileges() *schema.Resource {
 					"table",
 					"sequence",
 					"function",
+					"type",
 				}, false),
-				Description: "The PostgreSQL object type to set the default privileges on (one of: table, sequence, function)",
+				Description: "The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type)",
 			},
 			"privileges": &schema.Schema{
 				Type:        schema.TypeSet,

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -24,6 +24,7 @@ var objectTypes = map[string]string{
 	"table":    "r",
 	"sequence": "S",
 	"function": "f",
+	"type":     "T",
 }
 
 func resourcePostgreSQLGrant() *schema.Resource {

--- a/website/docs/r/postgresql_default_privileges.html.markdown
+++ b/website/docs/r/postgresql_default_privileges.html.markdown
@@ -32,5 +32,5 @@ resource "postgresql_default_privileges" "read_only_tables" {
 * `database` - (Required) The database to grant default privileges for this role.
 * `owner` - (Required) Role for which apply default privileges (You can change default privileges only for objects that will be created by yourself or by roles that you are a member of).
 * `schema` - (Required) The database schema to set default privileges for this role.
-* `object_type` - (Required) The PostgreSQL object type to set the default privileges on (one of: table, sequence,function).
+* `object_type` - (Required) The PostgreSQL object type to set the default privileges on (one of: table, sequence, function, type).
 * `privileges` - (Required) The list of privileges to apply as default privileges.


### PR DESCRIPTION
As asked in this [issue](https://github.com/terraform-providers/terraform-provider-postgresql/issues/95), I wanted to add support for functions and types for default privileges.

By the way, those two new objects types also suffers from this [issue](https://github.com/terraform-providers/terraform-provider-postgresql/issues/72)

I did not know how to test it, I can update the PR if anyone has ideas to improve the PR.