### PR TITLE
all resources: Grant object owners to connected user when needed.

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -38,7 +38,7 @@ func isRoleMember(db QueryAble, role, member string) (bool, error) {
 	case err == sql.ErrNoRows:
 		return false, nil
 	case err != nil:
-		return false, fmt.Errorf("could not real role membership: %w", err)
+		return false, fmt.Errorf("could not read role membership: %w", err)
 	}
 
 	return true, nil
@@ -84,6 +84,44 @@ func revokeRoleMembership(db QueryAble, role, member string) error {
 			return fmt.Errorf("Error revoking role %s from %s: %w", role, member, err)
 		}
 	}
+	return nil
+}
+
+// withRolesGranted temporarily grants, if needed, the roles specified to connected user
+// (i.e.: the admin configure in the provider) and revoke them as soon as the
+// callback func has finished.
+func withRolesGranted(txn *sql.Tx, roles []string, fn func() error) error {
+	// No roles asked, execute the function directly
+	if len(roles) == 0 {
+		return fn()
+	}
+
+	currentUser, err := getCurrentUser(txn)
+	if err != nil {
+		return err
+	}
+
+	var grantedRoles []string
+	for _, role := range roles {
+		roleGranted, err := grantRoleMembership(txn, role, currentUser)
+		if err != nil {
+			return err
+		}
+		if roleGranted {
+			grantedRoles = append(grantedRoles, role)
+		}
+	}
+
+	if err := fn(); err != nil {
+		return err
+	}
+
+	for _, role := range grantedRoles {
+		if err := revokeRoleMembership(txn, role, currentUser); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -192,6 +230,18 @@ func schemaExists(txn *sql.Tx, schemaname string) (bool, error) {
 	return true, nil
 }
 
+func getCurrentUser(db QueryAble) (string, error) {
+	var currentUser string
+	err := db.QueryRow("SELECT CURRENT_USER").Scan(&currentUser)
+	switch {
+	case err == sql.ErrNoRows:
+		return "", fmt.Errorf("SELECT CURRENT_USER returns now row, this is quite disturbing")
+	case err != nil:
+		return "", fmt.Errorf("error while looking for the current user: %w", err)
+	}
+	return currentUser, nil
+}
+
 // deferredRollback can be used to rollback a transaction in a defer.
 // It will log an error if it fails
 func deferredRollback(txn *sql.Tx) {
@@ -213,4 +263,64 @@ func getDatabase(d *schema.ResourceData, client *Client) string {
 	}
 
 	return database
+}
+
+func getDatabaseOwner(db QueryAble, database string) (string, error) {
+	query := `
+SELECT rolname
+  FROM pg_database
+  JOIN pg_roles ON datdba = pg_roles.oid
+  WHERE datname = $1
+`
+	var owner string
+
+	err := db.QueryRow(query, database).Scan(&owner)
+	switch {
+	case err == sql.ErrNoRows:
+		return "", fmt.Errorf("could not find database '%s' while looking for owner", database)
+	case err != nil:
+		return "", fmt.Errorf("error while looking for the owner of database '%s': %w", database, err)
+	}
+	return owner, nil
+}
+
+func getSchemaOwner(db QueryAble, schemaName string) (string, error) {
+	query := `
+SELECT rolname
+  FROM pg_namespace
+  JOIN pg_roles ON nspowner = pg_roles.oid
+  WHERE nspname = $1
+`
+	var owner string
+
+	err := db.QueryRow(query, schemaName).Scan(&owner)
+	switch {
+	case err == sql.ErrNoRows:
+		return "", fmt.Errorf("could not find schema '%s' while looking for owner", schemaName)
+	case err != nil:
+		return "", fmt.Errorf("error while looking for the owner of schema '%s': %w", schemaName, err)
+	}
+	return owner, nil
+}
+
+// getTablesOwner retrieves all the owners for all the tables in the specified schema.
+func getTablesOwner(db QueryAble, schemaName string) ([]string, error) {
+	rows, err := db.Query(
+		"SELECT DISTINCT tableowner FROM pg_tables WHERE schemaname = $1",
+		schemaName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error while looking for owners of tables in schema '%s': %w", schemaName, err)
+	}
+
+	var owners []string
+	for rows.Next() {
+		var owner string
+		if err := rows.Scan(&owner); err != nil {
+			return nil, fmt.Errorf("could not scan tables owner: %w", err)
+		}
+		owners = append(owners, owner)
+	}
+
+	return owners, nil
 }

--- a/postgresql/provider.go
+++ b/postgresql/provider.go
@@ -58,9 +58,9 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"superuser": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("PGSUPERUSER", true),
 				Description: "Specify if the user to connect as is a Postgres superuser or not." +
 					"If not, some feature might be disabled (e.g.: Refreshing state password from Postgres)",
 			},

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -180,8 +180,6 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 		fmt.Fprintf(b, " LC_COLLATE DEFAULT")
 	case ok:
 		fmt.Fprintf(b, " LC_COLLATE '%s' ", pqQuoteLiteral(v.(string)))
-	case v.(string) == "":
-		fmt.Fprint(b, ` LC_COLLATE 'C'`)
 	}
 
 	switch v, ok := d.GetOk(dbCTypeAttr); {
@@ -189,8 +187,6 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 		fmt.Fprintf(b, " LC_CTYPE DEFAULT")
 	case ok:
 		fmt.Fprintf(b, " LC_CTYPE '%s' ", pqQuoteLiteral(v.(string)))
-	case v.(string) == "":
-		fmt.Fprint(b, ` LC_CTYPE 'C'`)
 	}
 
 	switch v, ok := d.GetOk(dbTablespaceAttr); {

--- a/postgresql/resource_postgresql_database.go
+++ b/postgresql/resource_postgresql_database.go
@@ -175,6 +175,8 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 		fmt.Fprint(b, ` ENCODING 'UTF8'`)
 	}
 
+	// Don't specify LC_COLLATE if user didn't specify it
+	// This will use the default one (usually the one defined in the template database)
 	switch v, ok := d.GetOk(dbCollationAttr); {
 	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
 		fmt.Fprintf(b, " LC_COLLATE DEFAULT")
@@ -182,6 +184,8 @@ func createDatabase(c *Client, d *schema.ResourceData) error {
 		fmt.Fprintf(b, " LC_COLLATE '%s' ", pqQuoteLiteral(v.(string)))
 	}
 
+	// Don't specify LC_CTYPE if user didn't specify it
+	// This will use the default one (usually the one defined in the template database)
 	switch v, ok := d.GetOk(dbCTypeAttr); {
 	case ok && strings.ToUpper(v.(string)) == "DEFAULT":
 		fmt.Fprintf(b, " LC_CTYPE DEFAULT")

--- a/postgresql/resource_postgresql_database_test.go
+++ b/postgresql/resource_postgresql_database_test.go
@@ -386,7 +386,6 @@ resource "postgresql_database" "default_opts" {
    encoding = "UTF8"
    lc_collate = "C"
    lc_ctype = "C"
-   tablespace_name = "pg_default"
    connection_limit = -1
    is_template = false
 }
@@ -398,7 +397,6 @@ resource "postgresql_database" "modified_opts" {
    encoding = "UTF8"
    lc_collate = "en_US.UTF-8"
    lc_ctype = "en_US.UTF-8"
-   tablespace_name = "pg_default"
    connection_limit = 10
    is_template = true
 }
@@ -410,7 +408,6 @@ resource "postgresql_database" "pathological_opts" {
    encoding = "LATIN1"
    lc_collate = "C"
    lc_ctype = "C"
-   tablespace_name = "pg_default"
    connection_limit = 0
    is_template = true
 }

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -14,6 +14,9 @@ func TestAccPostgresqlExtension_Basic(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testCheckCompatibleVersion(t, featureExtension)
+			// TODO: Need to check how RDS manage to allow `rds_supuser` to create extension
+			// even it's not a real superuser
+			testSuperuserPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
@@ -116,6 +119,7 @@ func TestAccPostgresqlExtension_SchemaRename(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testCheckCompatibleVersion(t, featureExtension)
+			testSuperuserPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
@@ -182,6 +186,7 @@ func TestAccPostgresqlExtension_Database(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testCheckCompatibleVersion(t, featureExtension)
+			testSuperuserPreCheck(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,

--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -49,7 +49,6 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_create_database", "create_database", "true"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "name", "role_with_superuser"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_superuser", "superuser", "true"),
-					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "roles.#", "0"),
 
 					testAccCheckPostgresqlRoleExists("sub_role", []string{"myrole2", "role_simple"}, nil),
 					resource.TestCheckResourceAttr("postgresql_role.sub_role", "name", "sub_role"),

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -50,6 +50,7 @@ func resourcePostgreSQLSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
+				ForceNew:    true,
 				Description: "The database name to alter schema",
 			},
 			schemaOwnerAttr: {
@@ -121,25 +122,57 @@ func resourcePostgreSQLSchema() *schema.Resource {
 func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
-	queries := []string{}
-
-	database := getDatabase(d, c)
-
 	c.catalogLock.Lock()
 	defer c.catalogLock.Unlock()
 
+	database := getDatabase(d, c)
 	txn, err := startTransaction(c, database)
 	if err != nil {
 		return err
 	}
 	defer deferredRollback(txn)
 
+	// If the admin user is not a superuser (e.g. on AWS RDS)
+	// we'll need to temporary grant him:
+	//  * the owner of the db to have the permissions to create the schema
+	//  * the owner of the schema if specified in order to change its owner.
+	var rolesToGrant []string
+
+	dbOwner, err := getDatabaseOwner(txn, database)
+	if err != nil {
+		return err
+	}
+	rolesToGrant = append(rolesToGrant, dbOwner)
+
+	schemaOwner := d.Get("owner").(string)
+	if schemaOwner != "" && schemaOwner != dbOwner {
+		rolesToGrant = append(rolesToGrant, schemaOwner)
+
+	}
+
+	if err := withRolesGranted(txn, rolesToGrant, func() error {
+		return createSchema(d, c, txn)
+	}); err != nil {
+		return err
+	}
+
+	if err := txn.Commit(); err != nil {
+		return fmt.Errorf("Error committing schema: %w", err)
+	}
+
+	d.SetId(generateSchemaID(d, c))
+
+	return resourcePostgreSQLSchemaReadImpl(d, c)
+}
+
+func createSchema(d *schema.ResourceData, c *Client, txn *sql.Tx) error {
 	schemaName := d.Get(schemaNameAttr).(string)
 
 	// Check if previous tasks haven't already create schema
 	var foundSchema bool
-	err = txn.QueryRow(`SELECT TRUE FROM pg_catalog.pg_namespace WHERE nspname = $1`, schemaName).Scan(&foundSchema)
+	err := txn.QueryRow(`SELECT TRUE FROM pg_catalog.pg_namespace WHERE nspname = $1`, schemaName).Scan(&foundSchema)
 
+	queries := []string{}
 	if err == sql.ErrNoRows {
 		b := bytes.NewBufferString("CREATE SCHEMA ")
 		if c.featureSupported(featureSchemaCreateIfNotExist) {
@@ -194,22 +227,16 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if err := txn.Commit(); err != nil {
-		return fmt.Errorf("Error committing schema: %w", err)
-	}
-
-	d.SetId(generateSchemaID(d, c))
-
-	return resourcePostgreSQLSchemaReadImpl(d, c)
+	return nil
 }
 
 func resourcePostgreSQLSchemaDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
-	database := getDatabase(d, c)
-
 	c.catalogLock.Lock()
 	defer c.catalogLock.Unlock()
+
+	database := getDatabase(d, c)
 
 	txn, err := startTransaction(c, database)
 	if err != nil {
@@ -219,14 +246,31 @@ func resourcePostgreSQLSchemaDelete(d *schema.ResourceData, meta interface{}) er
 
 	schemaName := d.Get(schemaNameAttr).(string)
 
-	dropMode := "RESTRICT"
-	if d.Get(schemaDropCascade).(bool) {
-		dropMode = "CASCADE"
+	exists, err := schemaExists(txn, schemaName)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		d.SetId("")
+		return nil
 	}
 
-	sql := fmt.Sprintf("DROP SCHEMA %s %s", pq.QuoteIdentifier(schemaName), dropMode)
-	if _, err = txn.Exec(sql); err != nil {
-		return fmt.Errorf("Error deleting schema: %w", err)
+	owner := d.Get("owner").(string)
+
+	if err = withRolesGranted(txn, []string{owner}, func() error {
+		dropMode := "RESTRICT"
+		if d.Get(schemaDropCascade).(bool) {
+			dropMode = "CASCADE"
+		}
+
+		sql := fmt.Sprintf("DROP SCHEMA %s %s", pq.QuoteIdentifier(schemaName), dropMode)
+		if _, err = txn.Exec(sql); err != nil {
+			return fmt.Errorf("Error deleting schema: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	if err := txn.Commit(); err != nil {

--- a/postgresql/resource_postgresql_schema.go
+++ b/postgresql/resource_postgresql_schema.go
@@ -132,10 +132,10 @@ func resourcePostgreSQLSchemaCreate(d *schema.ResourceData, meta interface{}) er
 	}
 	defer deferredRollback(txn)
 
-	// If the admin user is not a superuser (e.g. on AWS RDS)
-	// we'll need to temporary grant him:
-	//  * the owner of the db to have the permissions to create the schema
-	//  * the owner of the schema if specified in order to change its owner.
+	// If the authenticated user is not a superuser (e.g. on AWS RDS)
+	// we'll need to temporarily grant it membership in the following roles:
+	//  * the owner of the db (to have the permissions to create the schema)
+	//  * the owner of the schema, if it has one (in order to change its owner)
 	var rolesToGrant []string
 
 	dbOwner, err := getDatabaseOwner(txn, database)

--- a/tests/env.sh
+++ b/tests/env.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-export TF_ACC=true	
-export PGHOST=localhost	
-export PGPORT=25432	
-export PGUSER=postgres	
-export PGPASSWORD=testpwd	
-export PGSSLMODE=disable

--- a/tests/switch_rds.sh
+++ b/tests/switch_rds.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+HERE=$(dirname $(readlink -f ${BASH_SOURCE:-${(%):-%N}}))
+
+source "$HERE/switch_superuser.sh"
+
+echo "Switching to an RDS-like environment"
+psql -d postgres  > /dev/null <<EOS
+BEGIN;
+    CREATE role rds LOGIN CREATEDB CREATEROLE PASSWORD 'rds';
+    -- On RDS, postgres user is member of these roles
+    -- But it's not really needed for the tests and pg_monitor is
+    -- not available on Posgres 8.x
+    -- GRANT pg_monitor,pg_signal_backend TO rds;
+    ALTER DATABASE postgres OWNER TO rds;
+    ALTER SCHEMA public OWNER TO rds;
+COMMIT;
+EOS
+
+psql -d template1 > /dev/null <<EOS
+BEGIN;
+    ALTER SCHEMA public OWNER TO rds;
+COMMIT;
+EOS
+
+export TF_ACC=true
+export PGHOST=localhost
+export PGPORT=25432
+export PGUSER=rds
+export PGPASSWORD=rds
+export PGSSLMODE=disable
+export PGSUPERUSER=false

--- a/tests/switch_superuser.sh
+++ b/tests/switch_superuser.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export TF_ACC=true
+export PGHOST=localhost
+export PGPORT=25432
+export PGUSER=postgres
+export PGPASSWORD=postgres
+export PGSSLMODE=disable
+export PGSUPERUSER=true

--- a/tests/testacc_cleanup.sh
+++ b/tests/testacc_cleanup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-source "$(pwd)"/tests/env.sh
+source "$(pwd)"/tests/switch_superuser.sh
 docker-compose -f "$(pwd)"/tests/docker-compose.yml down
-unset TF_ACC PGHOST PGPORT PGUSER PGPASSWORD PGSSLMODE
+unset TF_ACC PGHOST PGPORT PGUSER PGPASSWORD PGSSLMODE PGSUPERUSER

--- a/tests/testacc_full.sh
+++ b/tests/testacc_full.sh
@@ -12,12 +12,7 @@ setup() {
 }
 
 run() {
-  go clean -testcache
-  source "$(pwd)"/tests/env.sh
-  TF_ACC=1 go test ./postgresql -v -timeout 120m
-  
-  # for a single test comment the previous line and uncomment the next line
-  #TF_LOG=INFO TF_ACC=1 go test -v ./postgresql -run ^TestAccPostgresqlRole_Basic$ -timeout 360s
+  go test -count=1 ./postgresql -v -timeout 120m
   
   # keep the return value for the scripts to fail and clean properly
   return $?
@@ -27,7 +22,13 @@ cleanup() {
     "$(pwd)"/tests/testacc_cleanup.sh
 }
 
-## main
-log "setup" && setup 
-log "run" && run || (log "cleanup" && cleanup && exit 1)
-log "cleanup" && cleanup
+run_suite() {
+    suite=${1?}
+    log "setup ($1)" && setup
+    source "./tests/switch_$suite.sh"
+    log "run ($1)" && run || (log "cleanup" && cleanup && exit 1)
+    log "cleanup ($1)" && cleanup
+}
+
+run_suite "superuser"
+run_suite "rds"

--- a/tests/testacc_setup.sh
+++ b/tests/testacc_setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-source "$(pwd)"/tests/env.sh
+source "$(pwd)"/tests/switch_superuser.sh
 docker-compose -f "$(pwd)"/tests/docker-compose.yml up -d
 "$(pwd)"/tests/wait-postgres-docker.sh "$(pwd)"/tests/docker-compose.yml

--- a/tests/wait-postgres-docker.sh
+++ b/tests/wait-postgres-docker.sh
@@ -21,3 +21,4 @@ until docker-compose -f "$COMPOSE_FILE" logs postgres | grep "ready to accept co
     printf "."
     sleep 1
 done
+echo


### PR DESCRIPTION
This should fix most of permissions problems the provider has when running against RDS databases (and maybe other Cloud provider, but didn't test yet)

This also adds a new run of integration tests against a RDS-like Postgres.

Some tests are disabled for this environment, either because it really need to be superuser (e.g. to create a new superuser) or because the environment is not totally similar as RDS (e.g.: for the extensions, I need to check how I can reproduce RDS behavior).

This replaces #139 and #135 
Thanks to @slocke716 and @rimmington for your work on these problems that help me to create a more generic fix. If you have time to test this PR on your environment to assert it fixes your use cases, and even more to make a review of this PR, it would be very helpful :blush: .

This (hopefully) fixes #36 