### PR TITLE
Making possible to specify default 'role' parameter for the user

### DIFF
--- a/postgresql/resource_postgresql_role.go
+++ b/postgresql/resource_postgresql_role.go
@@ -496,8 +496,8 @@ func readSearchPath(roleConfig pq.ByteaArray) []string {
 func readRoleParameter(roleConfig pq.ByteaArray) string {
 	for _, v := range roleConfig {
 		config := string(v)
-		if strings.HasPrefix(config, roleRoleParameterAttr) {
-			var result = strings.TrimPrefix(config, roleRoleParameterAttr+"=")
+		if strings.HasPrefix(config, "role=") {
+			var result = strings.TrimPrefix(config, "role=")
 			return result
 		}
 	}
@@ -981,10 +981,6 @@ func setStatementTimeout(txn *sql.Tx, d *schema.ResourceData) error {
 }
 
 func alterRoleParameter(txn *sql.Tx, d *schema.ResourceData) error {
-	if !d.HasChange(roleRoleParameterAttr) {
-		return nil
-	}
-
 	roleName := d.Get(roleNameAttr).(string)
 	roleParameter := d.Get(roleRoleParameterAttr).(string)
 	if len(roleParameter) > 0 {

--- a/website/docs/r/postgresql_role.html.markdown
+++ b/website/docs/r/postgresql_role.html.markdown
@@ -85,6 +85,9 @@ resource "postgresql_role" "my_replication_role" {
 * `password` - (Optional) Sets the role's password. A password is only of use
   for roles having the `login` attribute set to true.
 
+* `role_parameter` - (Optional) Sets the `role` parameter for this role. The specified role
+  must be a part of `roles` list, unless this is a superuser.
+
 * `roles` - (Optional) Defines list of roles which will be granted to this new role.
 
 * `search_path` - (Optional) Alters the search path of this new role. Note that


### PR DESCRIPTION
This PR adds possibility to set the default `role` parameter for the user.
This is effectively the following statement on database level:
`ALTER ROLE role_name SET role TO role_parameter_value`

This is my first PR on github, so apologies if something is not filled in - just let me know and I'll fix this.

As for the code, it is my first golang code as well (yay!) - so I tried to stick to style of other parts of the code as closely as possible.

Looking at the code, it might be a good idea to somehow unify handling of default parameters - if there will be more. I'm willing to grab the subject in the future.