### PR TITLE
Setting a map of default parameters for Role. Draft, WIP

### DIFF
--- a/postgresql/resource_postgresql_role_test.go
+++ b/postgresql/resource_postgresql_role_test.go
@@ -342,6 +342,12 @@ resource "postgresql_role" "sub_role" {
 		"${postgresql_role.myrole2.id}",
 		"${postgresql_role.role_simple.id}",
 	]
+	parameters = {
+		application_name = "aaa"
+		role = "${postgresql_role.myrole2.id}"
+		//setting this will raise validation error	
+		//search_path = "aaa"
+	}
 }
 
 resource "postgresql_role" "role_with_search_path" {


### PR DESCRIPTION
This is an initial draft of extension of Role resource with map of default parameters.

The idea is to extend Role with the following section:
```
resource "postgresql_role" "sub_role" {
	name = "sub_role"
	roles = [
		"${postgresql_role.myrole2.id}",
		"${postgresql_role.role_simple.id}",
	]
	parameters = {
		application_name = "My app"
		role = "${postgresql_role.myrole2.id}"
	}
}
```
Parameters is a string->string map. I'm not sure yet how exactly will behave parameters of other types.
We would expect in this section no parameter that are currently implemented by standalone Role attribute property - as then scenario complicates a lot (it is the same parameter store in database).

I've implemented very rough draft - let's discuss 😄 There is only one super simple test - it's too late now to go further, so I'm leaving this as is. Any comments to code are welcome as well (I'm golang beginner).