### PR TITLE
Allow grant to specific tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.tool-versions
 
 website/vendor
 

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -225,7 +225,7 @@ func resourcePostgreSQLGrantDelete(d *schema.ResourceData, meta interface{}) err
 	return nil
 }
 
-func readDatabaseRolePriviges(txn *sql.Tx, d *schema.ResourceData) error {
+func readDatabaseRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	query := `
 SELECT privilege_type
 FROM (
@@ -257,7 +257,7 @@ func readRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	object_type := strings.ToUpper(d.Get("object_type").(string))
 	switch object_type {
 	case "DATABASE":
-		return readDatabaseRolePriviges(txn, d)
+		return readDatabaseRolePrivileges(txn, d)
 	case "FUNCTION":
 		query = `
 SELECT pg_proc.proname, array_remove(array_agg(privilege_type), NULL)

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -28,6 +28,8 @@ var objectTypes = map[string]string{
 	"type":     "T",
 }
 
+const tableGrantIdDelimiter = ":"
+
 func resourcePostgreSQLGrant() *schema.Resource {
 	return &schema.Resource{
 		Create: resourcePostgreSQLGrantCreate,
@@ -608,11 +610,11 @@ func generateGrantID(d *schema.ResourceData) string {
 	parts = append(parts, strings.Join(tables, ","))
 	parts = append(parts, strings.Join(privileges, ","))
 
-	return strings.Join(parts, ":")
+	return strings.Join(parts, tableGrantIdDelimiter)
 }
 
 func readTableGrantID(d *schema.ResourceData) (string, string, string, string, []string, []string) {
-	parts := strings.Split(d.Id(), ":")
+	parts := strings.Split(d.Id(), tableGrantIdDelimiter)
 
 	role := parts[0]
 	database := parts[1]

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -401,14 +401,8 @@ func createRevokeQuery(d *schema.ResourceData, tables []string) string {
 }
 
 func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
-	privileges := []string{}
-	for _, priv := range d.Get("privileges").(*schema.Set).List() {
-		privileges = append(privileges, priv.(string))
-	}
-	tables := []string{}
-	for _, tab := range d.Get("tables").(*schema.Set).List() {
-		tables = append(tables, tab.(string))
-	}
+	privileges := getStringsFromSet(d, "privileges")
+	tables := getStringsFromSet(d, "tables")
 
 	query := createGrantQuery(d, privileges, tables)
 
@@ -417,11 +411,10 @@ func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 }
 
 func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
-	tables := []string{}
-	for _, tab := range d.Get("tables").(*schema.Set).List() {
-		tables = append(tables, tab.(string))
-	}
+	tables := getStringsFromSet(d, "tables")
+
 	query := createRevokeQuery(d, tables)
+
 	if _, err := txn.Exec(query); err != nil {
 		return fmt.Errorf("could not execute revoke query: %w", err)
 	}
@@ -510,4 +503,12 @@ func getRolesToGrantForSchema(txn *sql.Tx, schemaName string) ([]string, error) 
 	}
 
 	return owners, nil
+}
+
+func getStringsFromSet(d *schema.ResourceData, setName string) []string {
+	strings := []string{}
+	for _, str := range d.Get(setName).(*schema.Set).List() {
+		strings = append(strings, str.(string))
+	}
+	return strings
 }

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -482,7 +482,15 @@ func generateGrantID(d *schema.ResourceData) string {
 	}
 	parts = append(parts, objectType)
 
-	return strings.Join(parts, "_")
+	tables := getStringsFromSet(d, "tables")
+	if len(tables) == 0 {
+		return strings.Join(parts, "_")
+	}
+
+	parts = append(parts, strings.Join(tables, ","))
+	parts = append(parts, strings.Join(getStringsFromSet(d, "privileges"), ","))
+
+	return strings.Join(parts, ":")
 }
 
 func getRolesToGrantForSchema(txn *sql.Tx, schemaName string) ([]string, error) {

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -514,21 +514,21 @@ func createRevokeQuery(d *schema.ResourceData, tables []string) string {
 func grantRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	privileges := getStringsFromSet(d, "privileges")
 	tables := getStringsFromSet(d, "tables")
-
 	query := createGrantQuery(d, privileges, tables)
 
 	_, err := txn.Exec(query)
+
 	return err
 }
 
 func revokeRolePrivileges(txn *sql.Tx, d *schema.ResourceData) error {
 	tables := getStringsFromSet(d, "tables")
-
 	query := createRevokeQuery(d, tables)
 
 	if _, err := txn.Exec(query); err != nil {
 		return fmt.Errorf("could not execute revoke query: %w", err)
 	}
+
 	return nil
 }
 

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -311,9 +311,9 @@ WHERE pg_tables.schemaname= $1
 
 	expectedTables := convertToSet(tables)
 	actualTables := convertToSet(actualTableNames)
+	// If tables do not have the same privileges as saved in the state,
+	// we return an empty privileges to force an update.
 	if !expectedTables.Equal(actualTables) {
-		// If table doesn't have the same privileges as saved in the state,
-		// we return an empty privileges to force an update.
 		log.Printf(
 			"[DEBUG] role %s expected to have privileges %v on tables %v but actually had privileges on tables %v",
 			role, privileges, tables, actualTableNames,
@@ -327,11 +327,11 @@ WHERE pg_tables.schemaname= $1
 	expectedPrivileges := convertToSet(privileges)
 	privilegesOk := true
 	for table, privs := range readTablePrivileges {
+		// If privileges are not the same as saved in the state,
+		// we return an empty privileges to force an update.
 		if !expectedPrivileges.Equal(privs) {
 			privilegesOk = false
 
-			// If privileges are not the same as saved in the state,
-			// we return an empty privileges to force an update.
 			log.Printf(
 				"[DEBUG] role %s on table %s expected to have privileges %v but actually had privileges on tables %v",
 				role, table, privileges, privs,

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -457,10 +457,20 @@ func createGrantQuery(d *schema.ResourceData, privileges []string, tables []stri
 		)
 	case "TABLE", "SEQUENCE", "FUNCTION":
 		if len(tables) > 0 {
+			schema := d.Get("schema").(string)
+			var tableNames []string
+			for _, table := range tables {
+				if schema == "" {
+					tableNames = append(tableNames, table)
+				} else {
+					tableNames = append(tableNames, fmt.Sprintf("%s.%s", schema, table))
+				}
+			}
+
 			query = fmt.Sprintf(
 				"GRANT %s ON TABLE %s TO %s",
 				strings.Join(privileges, ","),
-				strings.Join(tables, ","),
+				strings.Join(tableNames, ","),
 				pq.QuoteIdentifier(d.Get("role").(string)),
 			)
 		} else {
@@ -493,9 +503,19 @@ func createRevokeQuery(d *schema.ResourceData, tables []string) string {
 		)
 	case "TABLE", "SEQUENCE", "FUNCTION":
 		if len(tables) > 0 {
+			schema := d.Get("schema").(string)
+			var tableNames []string
+			for _, table := range tables {
+				if schema == "" {
+					tableNames = append(tableNames, table)
+				} else {
+					tableNames = append(tableNames, fmt.Sprintf("%s.%s", schema, table))
+				}
+			}
+
 			query = fmt.Sprintf(
 				"REVOKE ALL PRIVILEGES ON TABLE %s FROM %s",
-				strings.Join(tables, ","),
+				strings.Join(tableNames, ","),
 				pq.QuoteIdentifier(d.Get("role").(string)),
 			)
 		} else {

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -402,7 +402,7 @@ GROUP BY pg_class.relname
 `
 	}
 
-	if hasSpecificTableGrants(d) {
+	if d.Get("object_type").(string) == "table" && strings.Contains(d.Id(), tableGrantIdDelimiter) {
 		return readTableRolePrivileges(txn, d)
 	}
 
@@ -442,10 +442,6 @@ GROUP BY pg_class.relname
 	}
 
 	return nil
-}
-
-func hasSpecificTableGrants(d *schema.ResourceData) bool {
-	return d.Get("object_type").(string) == "table" && strings.Contains(d.Id(), ":")
 }
 
 func createGrantQuery(d *schema.ResourceData, privileges []string, tables []string) string {

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -487,8 +488,13 @@ func generateGrantID(d *schema.ResourceData) string {
 		return strings.Join(parts, "_")
 	}
 
+	privileges := getStringsFromSet(d, "privileges")
+
+	sort.Strings(tables)
+	sort.Strings(privileges)
+
 	parts = append(parts, strings.Join(tables, ","))
-	parts = append(parts, strings.Join(getStringsFromSet(d, "privileges"), ","))
+	parts = append(parts, strings.Join(privileges, ","))
 
 	return strings.Join(parts, ":")
 }

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -202,7 +202,7 @@ func TestGenerateGrantID(t *testing.T) {
 			}),
 			tables:     []string{"test_table"},
 			privileges: []string{"UPDATE", "TRIGGER"},
-			expected:   "bar:foo:some_schema:table:test_table:UPDATE,TRIGGER",
+			expected:   "bar:foo:some_schema:table:test_table:TRIGGER,UPDATE",
 		},
 	}
 

--- a/postgresql/resource_postgresql_grant_test.go
+++ b/postgresql/resource_postgresql_grant_test.go
@@ -95,6 +95,17 @@ func TestCreateGrantQuery(t *testing.T) {
 			tables:     []string{"apples", "oranges"},
 			expected:   fmt.Sprintf("GRANT SELECT,INSERT ON TABLE apples,oranges TO %s", pq.QuoteIdentifier(roleName)),
 		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "TABLE",
+				"database":    databaseName,
+				"schema":      "test_schema",
+				"role":        roleName,
+			}),
+			privileges: []string{"SELECT", "INSERT"},
+			tables:     []string{"apples", "oranges"},
+			expected:   fmt.Sprintf("GRANT SELECT,INSERT ON TABLE test_schema.apples,test_schema.oranges TO %s", pq.QuoteIdentifier(roleName)),
+		},
 	}
 
 	for _, c := range cases {
@@ -155,6 +166,16 @@ func TestCreateRevokeQuery(t *testing.T) {
 			}),
 			tables:   []string{"apples", "oranges"},
 			expected: fmt.Sprintf("REVOKE ALL PRIVILEGES ON TABLE apples,oranges FROM %s", pq.QuoteIdentifier(roleName)),
+		},
+		{
+			resource: schema.TestResourceDataRaw(t, resourcePostgreSQLGrant().Schema, map[string]interface{}{
+				"object_type": "TABLE",
+				"database":    databaseName,
+				"schema":      "test_schema",
+				"role":        roleName,
+			}),
+			tables:   []string{"apples", "oranges"},
+			expected: fmt.Sprintf("REVOKE ALL PRIVILEGES ON TABLE test_schema.apples,test_schema.oranges FROM %s", pq.QuoteIdentifier(roleName)),
 		},
 	}
 


### PR DESCRIPTION
Related to #85 

I have the use-case of granting specific privileges to specific tables (and [others seemed interested as well](https://github.com/terraform-providers/terraform-provider-postgresql/issues/85#issuecomment-521214625), so took a shot at doing that.

```
resource "postgresql_grant" "test" {
  role        = "some_role"
  object_type = "table"
  tables      = ["table1", "table2"]
  privileges  = ["SELECT"]
}
```

should produce the SQL `GRANT SELECT ON TABLE table1,table2 TO "some_role"`.

I was interested in writing an acceptance test but could not get them running. I tried this:

```
➜ TF_ACC=1 TF_LOG=INFO go test -v ./postgresql -run ^TestAccPostgresqlGrant$
=== RUN   TestAccPostgresqlGrant
2020/07/19 18:43:54 [INFO] PostgreSQL DSN: `host=localhost port=5432 dbname=postgres user='' password=<redacted> sslmode='' connect_timeout=0`
    TestAccPostgresqlGrant: utils_test.go:77: could not execute query CREATE ROLE tf_tests_role_1595198634363977000 LOGIN ENCRYPTED PASSWORD 'testpwd': pq: SSL is not enabled on the server
--- FAIL: TestAccPostgresqlGrant (0.01s)
FAIL
FAIL	github.com/terraform-providers/terraform-provider-postgresql/postgresql	0.037s
FAIL
```
I could try harder 😄 