### PR TITLE
Support DROP EXTENSION xx CASCADE

### DIFF
--- a/postgresql/resource_postgresql_extension.go
+++ b/postgresql/resource_postgresql_extension.go
@@ -13,10 +13,11 @@ import (
 )
 
 const (
-	extNameAttr     = "name"
-	extSchemaAttr   = "schema"
-	extVersionAttr  = "version"
-	extDatabaseAttr = "database"
+	extNameAttr        = "name"
+	extSchemaAttr      = "schema"
+	extVersionAttr     = "version"
+	extDatabaseAttr    = "database"
+	extDropCascadeAttr = "drop_cascade"
 )
 
 func resourcePostgreSQLExtension() *schema.Resource {
@@ -54,6 +55,12 @@ func resourcePostgreSQLExtension() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: "Sets the database to add the extension to",
+			},
+			extDropCascadeAttr: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When true, will also drop all the objects that depend on the extension, and in turn all objects that depend on those objects",
 			},
 		},
 	}
@@ -225,7 +232,12 @@ func resourcePostgreSQLExtensionDelete(d *schema.ResourceData, meta interface{})
 	}
 	defer deferredRollback(txn)
 
-	sql := fmt.Sprintf("DROP EXTENSION %s", pq.QuoteIdentifier(extName))
+	dropMode := "RESTRICT"
+	if d.Get(extDropCascadeAttr).(bool) {
+		dropMode = "CASCADE"
+	}
+
+	sql := fmt.Sprintf("DROP EXTENSION %s %s ", pq.QuoteIdentifier(extName), dropMode)
 	if _, err := txn.Exec(sql); err != nil {
 		return err
 	}

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -210,6 +210,8 @@ func TestAccPostgresqlExtension_Database(t *testing.T) {
 }
 
 func TestAccPostgresqlExtension_DropCascade(t *testing.T) {
+	skipIfNotAcc(t)
+
 	var testAccPostgresqlExtensionConfig = `
 resource "postgresql_extension" "cascade" {
   name = "pgcrypto"
@@ -217,7 +219,11 @@ resource "postgresql_extension" "cascade" {
 }
 `
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testCheckCompatibleVersion(t, featureExtension)
+			testSuperuserPreCheck(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
 		Steps: []resource.TestStep{

--- a/postgresql/resource_postgresql_extension_test.go
+++ b/postgresql/resource_postgresql_extension_test.go
@@ -209,6 +209,46 @@ func TestAccPostgresqlExtension_Database(t *testing.T) {
 	})
 }
 
+func TestAccPostgresqlExtension_DropCascade(t *testing.T) {
+	var testAccPostgresqlExtensionConfig = `
+resource "postgresql_extension" "cascade" {
+  name = "pgcrypto"
+  drop_cascade = true
+}
+`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPostgresqlExtensionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPostgresqlExtensionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPostgresqlExtensionExists("postgresql_extension.cascade"),
+					resource.TestCheckResourceAttr("postgresql_extension.cascade", "name", "pgcrypto"),
+					// This will create a dependency on the extension.
+					testAccCreateExtensionDependency("test_extension_cascade"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCreateExtensionDependency(tableName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		client := testAccProvider.Meta().(*Client)
+		db := client.DB()
+
+		_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s; CREATE TABLE %s (id uuid DEFAULT gen_random_uuid())", tableName, tableName))
+		if err != nil {
+			return fmt.Errorf("could not create test table in schema: %s", err)
+		}
+
+		return nil
+	}
+}
+
 var testAccPostgresqlExtensionConfig = `
 resource "postgresql_extension" "myextension" {
   name = "pg_trgm"


### PR DESCRIPTION
This allows to drop the extension even if it has dependencies.

Fix: #137

For the test: ideally there's a test where there's a dependency and `drop_cascade = false` and it shows it's failing. I'm not sure how to write that though.