### PR TITLE
remove prokind selection as is not available before PGSQL 11, fix #159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 1.8.0 (Unreleased)
+## 1.7.2 (unreleased)
+
+BUG FIXES:
+
+* `postgresql_grant` : fix grant on function by removing prokind column selection, 
+    as is it not available on postgresql version < 11 and its not to 
+    expect to have a window(w) or aggregate function(a) with the same name as a normal function(f)
+       
 ## 1.7.1 (July 30, 2020)
 
 BUG FIXES:

--- a/postgresql/resource_postgresql_grant.go
+++ b/postgresql/resource_postgresql_grant.go
@@ -257,13 +257,13 @@ JOIN pg_namespace ON pg_namespace.oid = pg_proc.pronamespace
 LEFT JOIN (
     select acls.*
     from (
-             SELECT proname, prokind, pronamespace, (aclexplode(proacl)).* FROM pg_proc
+             SELECT proname, pronamespace, (aclexplode(proacl)).* FROM pg_proc
          ) acls
     JOIN pg_roles on grantee = pg_roles.oid
     WHERE rolname = $1
 ) privs
-USING (proname, pronamespace, prokind)
-      WHERE nspname = $2 AND prokind = $3
+USING (proname, pronamespace)
+      WHERE nspname = $2 
 GROUP BY pg_proc.proname
 `
 	default:


### PR DESCRIPTION
This small fixes addresses issue #159  regarding grant on functions in versions before PGSQL11. I think its save to remove selection of column `prokind` (f=normal functions, a=aggregate function and w=window function)  from pgproc dataset as its not to expect to have the same name in more than one kind