### PR TITLE
Update schema import docs

### DIFF
--- a/website/docs/r/postgresql_schema.html.markdown
+++ b/website/docs/r/postgresql_schema.html.markdown
@@ -98,9 +98,10 @@ It is possible to import a `postgresql_schema` resource with the following
 command:
 
 ```
-$ terraform import postgresql_schema.schema_foo my_schema
+$ terraform import postgresql_schema.schema_foo my_database.my_schema
 ```
 
-Where `my_schema` is the name of the schema in the PostgreSQL database and
+Where `my_database` is the name of the database containing the schema,
+`my_schema` is the name of the schema in the PostgreSQL database and
 `postgresql_schema.schema_foo` is the name of the resource whose state will be
 populated as a result of the command.


### PR DESCRIPTION
Update import documentation to expected format as indicated from output error when not including database.

When using the existing `terraform import postgresql_schema.schema_foo my_schema` without specifying database the following error is produced.

```
Error: schema ID my_schema has not the expected format 'database.schema': [my_schema]
```

Docs updated to include missing database component of the ID.