### PR TITLE
feat: use lazy connections

### DIFF
--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -258,7 +258,6 @@ func startTransaction(client *Client, database string) (*sql.Tx, error) {
 			return nil, err
 		}
 	}
-	// spew.Dump(client)
 	db := client.DB()
 	txn, err := db.Begin()
 	if err != nil {

--- a/postgresql/helpers.go
+++ b/postgresql/helpers.go
@@ -258,6 +258,7 @@ func startTransaction(client *Client, database string) (*sql.Tx, error) {
 			return nil, err
 		}
 	}
+	// spew.Dump(client)
 	db := client.DB()
 	txn, err := db.Begin()
 	if err != nil {


### PR DESCRIPTION
Running an import action (or any action for that matter) which is not
touching posgres resources should not trigger the initialisation of the
postgres provider.

Same behaviour as terraform-provider-mysql.

Fixes #140

Signed-off-by: Enrico Stahn <enrico.stahn@gmail.com>